### PR TITLE
Remove Mutex around `Buffer`

### DIFF
--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -278,7 +278,7 @@ impl TextPipeline {
             min: min_width_content_size,
             max: max_width_content_size,
             font_system: Arc::clone(&self.font_system.0),
-            buffer: Mutex::new(buffer),
+            buffer,
         })
     }
 }
@@ -302,7 +302,7 @@ pub struct TextLayoutInfo {
 pub struct TextMeasureInfo {
     pub min: Vec2,
     pub max: Vec2,
-    buffer: Mutex<cosmic_text::Buffer>,
+    buffer: cosmic_text::Buffer,
     font_system: Arc<Mutex<cosmic_text::FontSystem>>,
 }
 
@@ -318,11 +318,11 @@ impl std::fmt::Debug for TextMeasureInfo {
 }
 
 impl TextMeasureInfo {
-    pub fn compute_size(&self, bounds: Vec2) -> Vec2 {
+    pub fn compute_size(&mut self, bounds: Vec2) -> Vec2 {
         let font_system = &mut self.font_system.try_lock().expect("Failed to acquire lock");
-        let mut buffer = self.buffer.lock().expect("Failed to acquire the lock");
-        buffer.set_size(font_system, Some(bounds.x.ceil()), Some(bounds.y.ceil()));
-        buffer_dimensions(&buffer)
+        self.buffer
+            .set_size(font_system, Some(bounds.x.ceil()), Some(bounds.y.ceil()));
+        buffer_dimensions(&self.buffer)
     }
 }
 

--- a/crates/bevy_ui/src/measurement.rs
+++ b/crates/bevy_ui/src/measurement.rs
@@ -21,7 +21,7 @@ impl std::fmt::Debug for ContentSize {
 pub trait Measure: Send + Sync + 'static {
     /// Calculate the size of the node given the constraints.
     fn measure(
-        &self,
+        &mut self,
         width: Option<f32>,
         height: Option<f32>,
         available_width: AvailableSpace,
@@ -44,7 +44,7 @@ pub enum NodeMeasure {
 
 impl Measure for NodeMeasure {
     fn measure(
-        &self,
+        &mut self,
         width: Option<f32>,
         height: Option<f32>,
         available_width: AvailableSpace,
@@ -78,7 +78,7 @@ pub struct FixedMeasure {
 
 impl Measure for FixedMeasure {
     fn measure(
-        &self,
+        &mut self,
         _: Option<f32>,
         _: Option<f32>,
         _: AvailableSpace,

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -38,7 +38,7 @@ pub struct ImageMeasure {
 
 impl Measure for ImageMeasure {
     fn measure(
-        &self,
+        &mut self,
         width: Option<f32>,
         height: Option<f32>,
         available_width: AvailableSpace,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -48,7 +48,7 @@ pub struct TextMeasure {
 
 impl Measure for TextMeasure {
     fn measure(
-        &self,
+        &mut self,
         width: Option<f32>,
         height: Option<f32>,
         available_width: AvailableSpace,


### PR DESCRIPTION
# Objective

- Removes one of the Mutexes from this PR (which is no longer needed)

## Solution

- Make the `Measure::measure` function take `&mut self` rather than `&self`