### PR TITLE
use `span` instead of `section` when referring to text

### DIFF
--- a/crates/bevy_dev_tools/src/fps_overlay.rs
+++ b/crates/bevy_dev_tools/src/fps_overlay.rs
@@ -11,7 +11,7 @@ use bevy_ecs::{
     system::{Commands, Query, Res, Resource},
 };
 use bevy_hierarchy::BuildChildren;
-use bevy_text::{Font, Text, TextSection, TextStyle};
+use bevy_text::{Font, Text, TextSpan, TextStyle};
 use bevy_ui::{
     node_bundles::{NodeBundle, TextBundle},
     PositionType, Style, ZIndex,
@@ -90,9 +90,9 @@ fn setup(mut commands: Commands, overlay_config: Res<FpsOverlayConfig>) {
         })
         .with_children(|c| {
             c.spawn((
-                TextBundle::from_sections([
-                    TextSection::new("FPS: ", overlay_config.text_config.clone()),
-                    TextSection::from_style(overlay_config.text_config.clone()),
+                TextBundle::from_spans([
+                    TextSpan::new("FPS: ", overlay_config.text_config.clone()),
+                    TextSpan::from_style(overlay_config.text_config.clone()),
                 ]),
                 FpsText,
             ));
@@ -103,7 +103,7 @@ fn update_text(diagnostic: Res<DiagnosticsStore>, mut query: Query<&mut Text, Wi
     for mut text in &mut query {
         if let Some(fps) = diagnostic.get(&FrameTimeDiagnosticsPlugin::FPS) {
             if let Some(value) = fps.smoothed() {
-                text.sections[1].value = format!("{value:.2}");
+                text.spans[1].value = format!("{value:.2}");
             }
         }
     }
@@ -114,8 +114,8 @@ fn customize_text(
     mut query: Query<&mut Text, With<FpsText>>,
 ) {
     for mut text in &mut query {
-        for section in text.sections.iter_mut() {
-            section.style = overlay_config.text_config.clone();
+        for span in text.spans.iter_mut() {
+            span.style = overlay_config.text_config.clone();
         }
     }
 }

--- a/crates/bevy_text/src/glyph.rs
+++ b/crates/bevy_text/src/glyph.rs
@@ -19,8 +19,8 @@ pub struct PositionedGlyph {
     pub size: Vec2,
     /// Information about the glyph's atlas.
     pub atlas_info: GlyphAtlasInfo,
-    /// The index of the glyph in the [`Text`](crate::Text)'s sections.
-    pub section_index: usize,
+    /// The index of the glyph in the [`Text`](crate::Text)'s spans.
+    pub span_index: usize,
     /// TODO: In order to do text editing, we need access to the size of glyphs and their index in the associated String.
     /// For example, to figure out where to place the cursor in an input box from the mouse's position.
     /// Without this, it's only possible in texts where each glyph is one byte. Cosmic text has methods for this
@@ -30,17 +30,12 @@ pub struct PositionedGlyph {
 
 impl PositionedGlyph {
     /// Creates a new [`PositionedGlyph`]
-    pub fn new(
-        position: Vec2,
-        size: Vec2,
-        atlas_info: GlyphAtlasInfo,
-        section_index: usize,
-    ) -> Self {
+    pub fn new(position: Vec2, size: Vec2, atlas_info: GlyphAtlasInfo, span_index: usize) -> Self {
         Self {
             position,
             size,
             atlas_info,
-            section_index,
+            span_index,
             byte_index: 0,
         }
     }

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -23,7 +23,7 @@
 //! or [`bevy_text::text2d::update_text2d_layout`] system (in a 2d world space context)
 //! passes it into [`TextPipeline::queue_text`], which:
 //!
-//! 1. creates a [`Buffer`](cosmic_text::Buffer) from the [`TextSection`]s, generating new [`FontAtlasSet`]s if necessary.
+//! 1. creates a [`Buffer`](cosmic_text::Buffer) from the [`TextSpan`]s, generating new [`FontAtlasSet`]s if necessary.
 //! 2. iterates over each glyph in the [`Buffer`](cosmic_text::Buffer) to create a [`PositionedGlyph`],
 //!    retrieving glyphs from the cache, or rasterizing to a [`FontAtlas`] if necessary.
 //! 3. [`PositionedGlyph`]s are stored in a [`TextLayoutInfo`],
@@ -55,7 +55,7 @@ pub use text2d::*;
 /// Most commonly used re-exported types.
 pub mod prelude {
     #[doc(hidden)]
-    pub use crate::{Font, JustifyText, Text, Text2dBundle, TextError, TextSection, TextStyle};
+    pub use crate::{Font, JustifyText, Text, Text2dBundle, TextError, TextSpan, TextStyle};
 }
 
 use bevy_app::prelude::*;

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -29,8 +29,8 @@ impl Default for CosmicBuffer {
 #[derive(Component, Debug, Clone, Default, Reflect)]
 #[reflect(Component, Default)]
 pub struct Text {
-    /// The text's sections
-    pub sections: Vec<TextSection>,
+    /// The text's spans
+    pub spans: Vec<TextSpan>,
     /// The text's internal alignment.
     /// Should not affect its position within a container.
     pub justify: JustifyText,
@@ -39,7 +39,7 @@ pub struct Text {
 }
 
 impl Text {
-    /// Constructs a [`Text`] with a single section.
+    /// Constructs a [`Text`] with a single span.
     ///
     /// ```
     /// # use bevy_asset::Handle;
@@ -49,7 +49,7 @@ impl Text {
     /// # let font_handle: Handle<Font> = Default::default();
     /// #
     /// // Basic usage.
-    /// let hello_world = Text::from_section(
+    /// let hello_world = Text::from_span(
     ///     // Accepts a String or any type that converts into a String, such as &str.
     ///     "hello world!",
     ///     TextStyle {
@@ -59,7 +59,7 @@ impl Text {
     ///     },
     /// );
     ///
-    /// let hello_bevy = Text::from_section(
+    /// let hello_bevy = Text::from_span(
     ///     "hello world\nand bevy!",
     ///     TextStyle {
     ///         font: font_handle.into(),
@@ -69,25 +69,25 @@ impl Text {
     /// ) // You can still add text justifaction.
     /// .with_justify(JustifyText::Center);
     /// ```
-    pub fn from_section(value: impl Into<String>, style: TextStyle) -> Self {
+    pub fn from_span(value: impl Into<String>, style: TextStyle) -> Self {
         Self {
-            sections: vec![TextSection::new(value, style)],
+            spans: vec![TextSpan::new(value, style)],
             ..default()
         }
     }
 
-    /// Constructs a [`Text`] from a list of sections.
+    /// Constructs a [`Text`] from a list of spans.
     ///
     /// ```
     /// # use bevy_asset::Handle;
     /// # use bevy_color::Color;
     /// # use bevy_color::palettes::basic::{RED, BLUE};
-    /// # use bevy_text::{Font, Text, TextStyle, TextSection};
+    /// # use bevy_text::{Font, Text, TextStyle, TextSpan};
     /// #
     /// # let font_handle: Handle<Font> = Default::default();
     /// #
-    /// let hello_world = Text::from_sections([
-    ///     TextSection::new(
+    /// let hello_world = Text::from_spans([
+    ///     TextSpan::new(
     ///         "Hello, ",
     ///         TextStyle {
     ///             font: font_handle.clone().into(),
@@ -95,7 +95,7 @@ impl Text {
     ///             color: BLUE.into(),
     ///         },
     ///     ),
-    ///     TextSection::new(
+    ///     TextSpan::new(
     ///         "World!",
     ///         TextStyle {
     ///             font: font_handle.into(),
@@ -105,9 +105,9 @@ impl Text {
     ///     ),
     /// ]);
     /// ```
-    pub fn from_sections(sections: impl IntoIterator<Item = TextSection>) -> Self {
+    pub fn from_spans(spans: impl IntoIterator<Item = TextSpan>) -> Self {
         Self {
-            sections: sections.into_iter().collect(),
+            spans: spans.into_iter().collect(),
             ..default()
         }
     }
@@ -126,17 +126,17 @@ impl Text {
     }
 }
 
-/// Contains the value of the text in a section and how it should be styled.
+/// Contains the value of the text in a span and how it should be styled.
 #[derive(Debug, Default, Clone, Reflect)]
-pub struct TextSection {
-    /// The content (in `String` form) of the text in the section.
+pub struct TextSpan {
+    /// The content (in `String` form) of the text in the span.
     pub value: String,
-    /// The style of the text in the section, including the font face, font size, and color.
+    /// The style of the text in the span, including the font face, font size, and color.
     pub style: TextStyle,
 }
 
-impl TextSection {
-    /// Create a new [`TextSection`].
+impl TextSpan {
+    /// Create a new [`TextSpan`].
     pub fn new(value: impl Into<String>, style: TextStyle) -> Self {
         Self {
             value: value.into(),
@@ -144,7 +144,7 @@ impl TextSection {
         }
     }
 
-    /// Create an empty [`TextSection`] from a style. Useful when the value will be set dynamically.
+    /// Create an empty [`TextSpan`] from a style. Useful when the value will be set dynamically.
     pub const fn from_style(style: TextStyle) -> Self {
         Self {
             value: String::new(),
@@ -154,7 +154,7 @@ impl TextSection {
 }
 
 #[cfg(feature = "default_font")]
-impl From<&str> for TextSection {
+impl From<&str> for TextSpan {
     fn from(value: &str) -> Self {
         Self {
             value: value.into(),
@@ -164,7 +164,7 @@ impl From<&str> for TextSection {
 }
 
 #[cfg(feature = "default_font")]
-impl From<String> for TextSection {
+impl From<String> for TextSpan {
     fn from(value: String) -> Self {
         Self {
             value,
@@ -194,7 +194,7 @@ pub enum JustifyText {
 }
 
 #[derive(Clone, Debug, Reflect)]
-/// `TextStyle` determines the style of the text in a section, specifically
+/// `TextStyle` determines the style of the text in a span, specifically
 /// the font face, the font size, and the color.
 pub struct TextStyle {
     /// The specific font face to use, as a `Handle` to a [`Font`] asset.
@@ -212,7 +212,7 @@ pub struct TextStyle {
     /// A new font atlas is generated for every combination of font handle and scaled font size
     /// which can have a strong performance impact.
     pub font_size: f32,
-    /// The color of the text for this section.
+    /// The color of the text for this span.
     pub color: Color,
 }
 

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -131,17 +131,17 @@ pub fn extract_text2d_sprite(
             * GlobalTransform::from_translation(alignment_translation.extend(0.))
             * scaling;
         let mut color = LinearRgba::WHITE;
-        let mut current_section = usize::MAX;
+        let mut current_span = usize::MAX;
         for PositionedGlyph {
             position,
             atlas_info,
-            section_index,
+            span_index,
             ..
         } in &text_layout_info.glyphs
         {
-            if *section_index != current_section {
-                color = LinearRgba::from(text.sections[*section_index].style.color);
-                current_section = *section_index;
+            if *span_index != current_span {
+                color = LinearRgba::from(text.spans[*span_index].style.color);
+                current_span = *span_index;
             }
             let atlas = texture_atlases.get(&atlas_info.texture_atlas).unwrap();
 
@@ -214,7 +214,7 @@ pub fn update_text2d_layout(
 
             match text_pipeline.queue_text(
                 &fonts,
-                &text.sections,
+                &text.spans,
                 scale_factor.into(),
                 text.justify,
                 text.linebreak_behavior,
@@ -323,7 +323,7 @@ mod tests {
         let entity = app
             .world_mut()
             .spawn((Text2dBundle {
-                text: Text::from_section(FIRST_TEXT, default()),
+                text: Text::from_span(FIRST_TEXT, default()),
                 ..default()
             },))
             .id();
@@ -379,7 +379,7 @@ mod tests {
             .expect("Could not find entity");
         *entity_ref
             .get_mut::<Text>()
-            .expect("Missing Text on entity") = Text::from_section(SECOND_TEXT, default());
+            .expect("Missing Text on entity") = Text::from_span(SECOND_TEXT, default());
 
         // Recomputes the AABB.
         app.update();

--- a/crates/bevy_ui/src/accessibility.rs
+++ b/crates/bevy_ui/src/accessibility.rs
@@ -24,7 +24,7 @@ fn calc_name(texts: &Query<&Text>, children: &Children) -> Option<Box<str>> {
     for child in children {
         if let Ok(text) = texts.get(*child) {
             let values = text
-                .sections
+                .spans
                 .iter()
                 .map(|v| v.value.to_string())
                 .collect::<Vec<String>>();
@@ -118,7 +118,7 @@ fn label_changed(
 ) {
     for (entity, text, accessible) in &mut query {
         let values = text
-            .sections
+            .spans
             .iter()
             .map(|v| v.value.to_string())
             .collect::<Vec<String>>();

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -16,7 +16,7 @@ use bevy_render::view::{InheritedVisibility, ViewVisibility, Visibility};
 use bevy_sprite::TextureAtlas;
 #[cfg(feature = "bevy_text")]
 use bevy_text::{
-    BreakLineOn, CosmicBuffer, JustifyText, Text, TextLayoutInfo, TextSection, TextStyle,
+    BreakLineOn, CosmicBuffer, JustifyText, Text, TextLayoutInfo, TextSpan, TextStyle,
 };
 use bevy_transform::prelude::{GlobalTransform, Transform};
 
@@ -244,22 +244,22 @@ impl Default for TextBundle {
 
 #[cfg(feature = "bevy_text")]
 impl TextBundle {
-    /// Create a [`TextBundle`] from a single section.
+    /// Create a [`TextBundle`] from a single span.
     ///
-    /// See [`Text::from_section`] for usage.
-    pub fn from_section(value: impl Into<String>, style: TextStyle) -> Self {
+    /// See [`Text::from_span`] for usage.
+    pub fn from_span(value: impl Into<String>, style: TextStyle) -> Self {
         Self {
-            text: Text::from_section(value, style),
+            text: Text::from_span(value, style),
             ..Default::default()
         }
     }
 
-    /// Create a [`TextBundle`] from a list of sections.
+    /// Create a [`TextBundle`] from a list of spans.
     ///
-    /// See [`Text::from_sections`] for usage.
-    pub fn from_sections(sections: impl IntoIterator<Item = TextSection>) -> Self {
+    /// See [`Text::from_spans`] for usage.
+    pub fn from_spans(spans: impl IntoIterator<Item = TextSpan>) -> Self {
         Self {
-            text: Text::from_sections(sections),
+            text: Text::from_spans(spans),
             ..Default::default()
         }
     }
@@ -293,10 +293,10 @@ impl TextBundle {
 #[cfg(feature = "bevy_text")]
 impl<I> From<I> for TextBundle
 where
-    I: Into<TextSection>,
+    I: Into<TextSpan>,
 {
     fn from(value: I) -> Self {
-        Self::from_sections(vec![value.into()])
+        Self::from_spans(vec![value.into()])
     }
 }
 

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -843,17 +843,17 @@ pub fn extract_uinode_text(
         transform.translation *= inverse_scale_factor;
 
         let mut color = LinearRgba::WHITE;
-        let mut current_section = usize::MAX;
+        let mut current_span = usize::MAX;
         for PositionedGlyph {
             position,
             atlas_info,
-            section_index,
+            span_index,
             ..
         } in &text_layout_info.glyphs
         {
-            if *section_index != current_section {
-                color = LinearRgba::from(text.sections[*section_index].style.color);
-                current_section = *section_index;
+            if *span_index != current_span {
+                color = LinearRgba::from(text.spans[*span_index].style.color);
+                current_span = *span_index;
             }
             let atlas = texture_atlases.get(&atlas_info.texture_atlas).unwrap();
 

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -92,7 +92,7 @@ fn create_text_measure(
 ) {
     match text_pipeline.create_text_measure(
         fonts,
-        &text.sections,
+        &text.spans,
         scale_factor,
         text.linebreak_behavior,
         buffer,
@@ -217,7 +217,7 @@ fn queue_text(
 
         match text_pipeline.queue_text(
             fonts,
-            &text.sections,
+            &text.spans,
             scale_factor.into(),
             text.justify,
             text.linebreak_behavior,

--- a/examples/2d/2d_shapes.rs
+++ b/examples/2d/2d_shapes.rs
@@ -58,13 +58,14 @@ fn setup(
     }
 
     commands.spawn(
-        TextBundle::from_section("Press space to toggle wireframes", TextStyle::default())
-            .with_style(Style {
+        TextBundle::from_span("Press space to toggle wireframes", TextStyle::default()).with_style(
+            Style {
                 position_type: PositionType::Absolute,
                 top: Val::Px(12.0),
                 left: Val::Px(12.0),
                 ..default()
-            }),
+            },
+        ),
     );
 }
 

--- a/examples/2d/bloom_2d.rs
+++ b/examples/2d/bloom_2d.rs
@@ -66,7 +66,7 @@ fn setup(
 
     // UI
     commands.spawn(
-        TextBundle::from_section("", TextStyle::default()).with_style(Style {
+        TextBundle::from_span("", TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             bottom: Val::Px(12.0),
             left: Val::Px(12.0),
@@ -86,7 +86,7 @@ fn update_bloom_settings(
 ) {
     let bloom_settings = camera.single_mut();
     let mut text = text.single_mut();
-    let text = &mut text.sections[0].value;
+    let text = &mut text.spans[0].value;
 
     match bloom_settings {
         (entity, Some(mut bloom_settings)) => {

--- a/examples/2d/bounding_2d.rs
+++ b/examples/2d/bounding_2d.rs
@@ -74,7 +74,7 @@ fn update_text(mut text: Query<&mut Text>, cur_state: Res<State<Test>>) {
     }
 
     let mut text = text.single_mut();
-    let text = &mut text.sections[0].value;
+    let text = &mut text.spans[0].value;
     text.clear();
 
     text.push_str("Intersection test:\n");
@@ -267,7 +267,7 @@ fn setup(mut commands: Commands) {
     ));
 
     commands.spawn(
-        TextBundle::from_section("", TextStyle::default()).with_style(Style {
+        TextBundle::from_span("", TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             bottom: Val::Px(12.0),
             left: Val::Px(12.0),

--- a/examples/2d/sprite_animation.rs
+++ b/examples/2d/sprite_animation.rs
@@ -140,7 +140,7 @@ fn setup(
 
     // create a minimal UI explaining how to interact with the example
     commands.spawn(TextBundle {
-        text: Text::from_section(
+        text: Text::from_span(
             "Left Arrow Key: Animate Left Sprite\nRight Arrow Key: Animate Right Sprite",
             TextStyle::default(),
         ),

--- a/examples/2d/sprite_slice.rs
+++ b/examples/2d/sprite_slice.rs
@@ -98,7 +98,7 @@ fn spawn_sprites(
         }
         cmd.with_children(|builder| {
             builder.spawn(Text2dBundle {
-                text: Text::from_section(label, text_style).with_justify(JustifyText::Center),
+                text: Text::from_span(label, text_style).with_justify(JustifyText::Center),
                 transform: Transform::from_xyz(0., -0.5 * size.y - 10., 0.0),
                 text_anchor: bevy::sprite::Anchor::TopCenter,
                 ..default()

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -45,7 +45,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Demonstrate changing translation
     commands.spawn((
         Text2dBundle {
-            text: Text::from_section("translation", text_style.clone())
+            text: Text::from_span("translation", text_style.clone())
                 .with_justify(text_justification),
             ..default()
         },
@@ -54,8 +54,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Demonstrate changing rotation
     commands.spawn((
         Text2dBundle {
-            text: Text::from_section("rotation", text_style.clone())
-                .with_justify(text_justification),
+            text: Text::from_span("rotation", text_style.clone()).with_justify(text_justification),
             ..default()
         },
         AnimateRotation,
@@ -63,7 +62,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Demonstrate changing scale
     commands.spawn((
         Text2dBundle {
-            text: Text::from_section("scale", text_style).with_justify(text_justification),
+            text: Text::from_span("scale", text_style).with_justify(text_justification),
             transform: Transform::from_translation(Vec3::new(400.0, 0.0, 0.0)),
             ..default()
         },
@@ -90,7 +89,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .with_children(|builder| {
             builder.spawn(Text2dBundle {
                 text: Text {
-                    sections: vec![TextSection::new(
+                    spans: vec![TextSpan::new(
                         "this text wraps in the box\n(Unicode linebreaks)",
                         slightly_smaller_text_style.clone(),
                     )],
@@ -122,7 +121,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .with_children(|builder| {
             builder.spawn(Text2dBundle {
                 text: Text {
-                    sections: vec![TextSection::new(
+                    spans: vec![TextSpan::new(
                         "this text wraps in the box\n(AnyCharacter linebreaks)",
                         slightly_smaller_text_style.clone(),
                     )],
@@ -147,7 +146,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     ] {
         commands.spawn(Text2dBundle {
             text: Text {
-                sections: vec![TextSection::new(
+                spans: vec![TextSpan::new(
                     format!(" Anchor::{text_anchor:?} "),
                     TextStyle {
                         color,

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -265,7 +265,7 @@ fn create_label(
     text_style: TextStyle,
 ) {
     commands.spawn(Text2dBundle {
-        text: Text::from_section(text, text_style).with_justify(JustifyText::Center),
+        text: Text::from_span(text, text_style).with_justify(JustifyText::Center),
         transform: Transform {
             translation: Vec3::new(translation.0, translation.1, translation.2),
             ..default()

--- a/examples/2d/wireframe_2d.rs
+++ b/examples/2d/wireframe_2d.rs
@@ -99,7 +99,7 @@ fn setup(
 
     // Text used to show controls
     commands.spawn(
-        TextBundle::from_section("", TextStyle::default()).with_style(Style {
+        TextBundle::from_span("", TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),
             left: Val::Px(12.0),
@@ -115,7 +115,7 @@ fn update_colors(
     mut wireframe_colors: Query<&mut Wireframe2dColor>,
     mut text: Query<&mut Text>,
 ) {
-    text.single_mut().sections[0].value = format!(
+    text.single_mut().spans[0].value = format!(
         "Controls
 ---------------
 Z - Toggle global

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -129,13 +129,14 @@ fn setup(
     });
 
     commands.spawn(
-        TextBundle::from_section("Press space to toggle wireframes", TextStyle::default())
-            .with_style(Style {
+        TextBundle::from_span("Press space to toggle wireframes", TextStyle::default()).with_style(
+            Style {
                 position_type: PositionType::Absolute,
                 top: Val::Px(12.0),
                 left: Val::Px(12.0),
                 ..default()
-            }),
+            },
+        ),
     );
 }
 

--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -294,7 +294,7 @@ impl AppStatus {
         };
 
         // Build the `Text` object.
-        Text::from_section(
+        Text::from_span(
             format!("{}\n{}", material_variant_help_text, light_help_text),
             TextStyle {
                 font: asset_server.load("fonts/FiraMono-Medium.ttf"),

--- a/examples/3d/anti_aliasing.rs
+++ b/examples/3d/anti_aliasing.rs
@@ -185,7 +185,7 @@ fn update_ui(
     let (fxaa, smaa, taa, cas_settings) = camera.single();
 
     let mut ui = ui.single_mut();
-    let ui = &mut ui.sections[0].value;
+    let ui = &mut ui.spans[0].value;
 
     *ui = "Antialias Method\n".to_string();
 
@@ -337,7 +337,7 @@ fn setup(
 
     // example instructions
     commands.spawn(
-        TextBundle::from_section("", TextStyle::default()).with_style(Style {
+        TextBundle::from_span("", TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),
             left: Val::Px(12.0),

--- a/examples/3d/atmospheric_fog.rs
+++ b/examples/3d/atmospheric_fog.rs
@@ -96,7 +96,7 @@ fn setup_terrain_scene(
 
 fn setup_instructions(mut commands: Commands) {
     commands.spawn(
-        TextBundle::from_section(
+        TextBundle::from_span(
             "Press Spacebar to Toggle Atmospheric Fog.\nPress S to Toggle Directional Light Fog Influence.",
             TextStyle::default(),
         )

--- a/examples/3d/auto_exposure.rs
+++ b/examples/3d/auto_exposure.rs
@@ -134,7 +134,7 @@ fn setup(
     let text_style = TextStyle::default();
 
     commands.spawn(
-        TextBundle::from_section(
+        TextBundle::from_span(
             "Left / Right - Rotate Camera\nC - Toggle Compensation Curve\nM - Toggle Metering Mask\nV - Visualize Metering Mask",
             text_style.clone(),
         )
@@ -147,7 +147,7 @@ fn setup(
     );
 
     commands.spawn((
-        TextBundle::from_section("", text_style).with_style(Style {
+        TextBundle::from_span("", text_style).with_style(Style {
             position_type: PositionType::Absolute,
             top: Val::Px(10.0),
             right: Val::Px(10.0),
@@ -211,7 +211,7 @@ fn example_control_system(
     };
 
     let mut display = display.single_mut();
-    display.sections[0].value = format!(
+    display.spans[0].value = format!(
         "Compensation Curve: {}\nMetering Mask: {}",
         if auto_exposure.compensation_curve == resources.basic_compensation_curve {
             "Enabled"

--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -191,7 +191,7 @@ fn setup(
     };
 
     commands.spawn(
-        TextBundle::from_section(
+        TextBundle::from_span(
             "Up / Down — Increase / Decrease Alpha\nLeft / Right — Rotate Camera\nH - Toggle HDR\nSpacebar — Toggle Unlit\nC — Randomize Colors",
             text_style.clone(),
         )
@@ -204,7 +204,7 @@ fn setup(
     );
 
     commands.spawn((
-        TextBundle::from_section("", text_style).with_style(Style {
+        TextBundle::from_span("", text_style).with_style(Style {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),
             right: Val::Px(12.0),
@@ -227,7 +227,7 @@ fn setup(
             ))
             .with_children(|parent| {
                 parent.spawn(
-                    TextBundle::from_section(label, label_text_style.clone())
+                    TextBundle::from_span(label, label_text_style.clone())
                         .with_style(Style {
                             position_type: PositionType::Absolute,
                             bottom: Val::ZERO,
@@ -345,7 +345,7 @@ fn example_control_system(
     }
 
     let mut display = display.single_mut();
-    display.sections[0].value = format!(
+    display.spans[0].value = format!(
         "  HDR: {}\nAlpha: {:.2}",
         if camera.hdr { "ON " } else { "OFF" },
         state.alpha

--- a/examples/3d/bloom_3d.rs
+++ b/examples/3d/bloom_3d.rs
@@ -89,7 +89,7 @@ fn setup_scene(
 
     // example instructions
     commands.spawn(
-        TextBundle::from_section("", TextStyle::default()).with_style(Style {
+        TextBundle::from_span("", TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             bottom: Val::Px(12.0),
             left: Val::Px(12.0),
@@ -109,7 +109,7 @@ fn update_bloom_settings(
 ) {
     let bloom_settings = camera.single_mut();
     let mut text = text.single_mut();
-    let text = &mut text.sections[0].value;
+    let text = &mut text.spans[0].value;
 
     match bloom_settings {
         (entity, Some(mut bloom_settings)) => {

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -337,6 +337,6 @@ impl LightMode {
             LightMode::Directional => "Press Space to switch to a point light",
         };
 
-        Text::from_section(help_text, TextStyle::default())
+        Text::from_span(help_text, TextStyle::default())
     }
 }

--- a/examples/3d/color_grading.rs
+++ b/examples/3d/color_grading.rs
@@ -322,7 +322,7 @@ fn add_help_text(
                 top: Val::Px(10.0),
                 ..default()
             },
-            ..TextBundle::from_section(
+            ..TextBundle::from_span(
                 create_help_text(currently_selected_option),
                 TextStyle {
                     font: font.clone(),
@@ -340,7 +340,7 @@ fn add_text<'a>(
     font: &Handle<Font>,
     color: Color,
 ) -> EntityCommands<'a> {
-    parent.spawn(TextBundle::from_section(
+    parent.spawn(TextBundle::from_span(
         label,
         TextStyle {
             font: font.clone(),
@@ -606,8 +606,8 @@ fn update_ui_state(
             Color::WHITE
         };
 
-        for section in &mut text.sections {
-            section.style.color = color;
+        for span in &mut text.spans {
+            span.style.color = color;
         }
 
         // Update the displayed value, if this is the currently-selected option.
@@ -615,15 +615,15 @@ fn update_ui_state(
             && *currently_selected_option == widget.option
         {
             if let Some(ref value_label) = value_label {
-                for section in &mut text.sections {
-                    section.value.clone_from(value_label);
+                for span in &mut text.spans {
+                    span.value.clone_from(value_label);
                 }
             }
         }
     }
 
     // Update the help text.
-    help_text.single_mut().sections[0].value = create_help_text(&currently_selected_option);
+    help_text.single_mut().spans[0].value = create_help_text(&currently_selected_option);
 }
 
 /// Creates the help text at the top left of the window.

--- a/examples/3d/deferred_rendering.rs
+++ b/examples/3d/deferred_rendering.rs
@@ -205,7 +205,7 @@ fn setup(
 
     // Example instructions
     commands.spawn(
-        TextBundle::from_section("", TextStyle::default()).with_style(Style {
+        TextBundle::from_span("", TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),
             left: Val::Px(12.0),
@@ -311,7 +311,7 @@ fn switch_mode(
     mut mode: Local<DefaultRenderMode>,
 ) {
     let mut text = text.single_mut();
-    let text = &mut text.sections[0].value;
+    let text = &mut text.spans[0].value;
 
     text.clear();
 

--- a/examples/3d/depth_of_field.rs
+++ b/examples/3d/depth_of_field.rs
@@ -223,7 +223,7 @@ fn update_text(mut texts: Query<&mut Text>, app_settings: Res<AppSettings>) {
 
 /// Regenerates the app text component per the current app settings.
 fn create_text(app_settings: &AppSettings) -> Text {
-    Text::from_section(app_settings.help_text(), TextStyle::default())
+    Text::from_span(app_settings.help_text(), TextStyle::default())
 }
 
 impl From<AppSettings> for Option<DepthOfFieldSettings> {

--- a/examples/3d/fog.rs
+++ b/examples/3d/fog.rs
@@ -124,7 +124,7 @@ fn setup_pyramid_scene(
 
 fn setup_instructions(mut commands: Commands) {
     commands.spawn(
-        TextBundle::from_section("", TextStyle::default()).with_style(Style {
+        TextBundle::from_span("", TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),
             left: Val::Px(12.0),
@@ -155,10 +155,10 @@ fn update_system(
     .looking_at(Vec3::ZERO, Vec3::Y);
 
     // Fog Information
-    text.sections[0].value = format!("Fog Falloff: {:?}\nFog Color: {:?}", fog.falloff, fog.color);
+    text.spans[0].value = format!("Fog Falloff: {:?}\nFog Color: {:?}", fog.falloff, fog.color);
 
     // Fog Falloff Mode Switching
-    text.sections[0]
+    text.spans[0]
         .value
         .push_str("\n\n1 / 2 / 3 - Fog Falloff Mode");
 
@@ -199,7 +199,7 @@ fn update_system(
         ref mut end,
     } = &mut fog.falloff
     {
-        text.sections[0]
+        text.spans[0]
             .value
             .push_str("\nA / S - Move Start Distance\nZ / X - Move End Distance");
 
@@ -219,7 +219,7 @@ fn update_system(
 
     // Exponential Fog Controls
     if let FogFalloff::Exponential { ref mut density } = &mut fog.falloff {
-        text.sections[0].value.push_str("\nA / S - Change Density");
+        text.spans[0].value.push_str("\nA / S - Change Density");
 
         if keycode.pressed(KeyCode::KeyA) {
             *density -= delta * 0.5 * *density;
@@ -234,7 +234,7 @@ fn update_system(
 
     // ExponentialSquared Fog Controls
     if let FogFalloff::ExponentialSquared { ref mut density } = &mut fog.falloff {
-        text.sections[0].value.push_str("\nA / S - Change Density");
+        text.spans[0].value.push_str("\nA / S - Change Density");
 
         if keycode.pressed(KeyCode::KeyA) {
             *density -= delta * 0.5 * *density;
@@ -248,7 +248,7 @@ fn update_system(
     }
 
     // RGBA Controls
-    text.sections[0]
+    text.spans[0]
         .value
         .push_str("\n\n- / = - Red\n[ / ] - Green\n; / ' - Blue\n. / ? - Alpha");
 

--- a/examples/3d/generate_custom_mesh.rs
+++ b/examples/3d/generate_custom_mesh.rs
@@ -64,7 +64,7 @@ fn setup(
 
     // Text to describe the controls.
     commands.spawn(
-        TextBundle::from_section(
+        TextBundle::from_span(
             "Controls:\nSpace: Change UVs\nX/Y/Z: Rotate\nR: Reset orientation",
             TextStyle::default(),
         )

--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -348,7 +348,7 @@ impl AppStatus {
             ExampleModel::Fox => SWITCH_TO_SPHERE_HELP_TEXT,
         };
 
-        Text::from_section(
+        Text::from_span(
             format!(
                 "{}\n{}\n{}\n{}\n{}",
                 CLICK_TO_MOVE_HELP_TEXT,

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -234,30 +234,30 @@ fn setup(
     let style = TextStyle::default();
 
     commands.spawn(
-        TextBundle::from_sections(vec![
-            TextSection::new(
+        TextBundle::from_spans(vec![
+            TextSpan::new(
                 format!("Aperture: f/{:.0}\n", parameters.aperture_f_stops),
                 style.clone(),
             ),
-            TextSection::new(
+            TextSpan::new(
                 format!(
                     "Shutter speed: 1/{:.0}s\n",
                     1.0 / parameters.shutter_speed_s
                 ),
                 style.clone(),
             ),
-            TextSection::new(
+            TextSpan::new(
                 format!("Sensitivity: ISO {:.0}\n", parameters.sensitivity_iso),
                 style.clone(),
             ),
-            TextSection::new("\n\n", style.clone()),
-            TextSection::new("Controls\n", style.clone()),
-            TextSection::new("---------------\n", style.clone()),
-            TextSection::new("Arrow keys - Move objects\n", style.clone()),
-            TextSection::new("1/2 - Decrease/Increase aperture\n", style.clone()),
-            TextSection::new("3/4 - Decrease/Increase shutter speed\n", style.clone()),
-            TextSection::new("5/6 - Decrease/Increase sensitivity\n", style.clone()),
-            TextSection::new("R - Reset exposure", style),
+            TextSpan::new("\n\n", style.clone()),
+            TextSpan::new("Controls\n", style.clone()),
+            TextSpan::new("---------------\n", style.clone()),
+            TextSpan::new("Arrow keys - Move objects\n", style.clone()),
+            TextSpan::new("1/2 - Decrease/Increase aperture\n", style.clone()),
+            TextSpan::new("3/4 - Decrease/Increase shutter speed\n", style.clone()),
+            TextSpan::new("5/6 - Decrease/Increase sensitivity\n", style.clone()),
+            TextSpan::new("R - Reset exposure", style),
         ])
         .with_style(Style {
             position_type: PositionType::Absolute,
@@ -302,12 +302,12 @@ fn update_exposure(
         *parameters = Parameters::default();
     }
 
-    text.sections[0].value = format!("Aperture: f/{:.0}\n", parameters.aperture_f_stops);
-    text.sections[1].value = format!(
+    text.spans[0].value = format!("Aperture: f/{:.0}\n", parameters.aperture_f_stops);
+    text.spans[1].value = format!(
         "Shutter speed: 1/{:.0}s\n",
         1.0 / parameters.shutter_speed_s
     );
-    text.sections[2].value = format!("Sensitivity: ISO {:.0}\n", parameters.sensitivity_iso);
+    text.spans[2].value = format!("Sensitivity: ISO {:.0}\n", parameters.sensitivity_iso);
 
     *exposure.single_mut() = Exposure::from_physical_camera(**parameters);
 }

--- a/examples/3d/load_gltf_extras.rs
+++ b/examples/3d/load_gltf_extras.rs
@@ -37,7 +37,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // a place to display the extras on screen
     commands.spawn((
-        TextBundle::from_section(
+        TextBundle::from_span(
             "",
             TextStyle {
                 font_size: 18.,
@@ -92,6 +92,6 @@ fn check_for_gltf_extras(
             gltf_extra_infos_lines.push(formatted_extras);
         }
         let mut display = display.single_mut();
-        display.sections[0].value = gltf_extra_infos_lines.join("\n");
+        display.spans[0].value = gltf_extra_infos_lines.join("\n");
     }
 }

--- a/examples/3d/motion_blur.rs
+++ b/examples/3d/motion_blur.rs
@@ -255,12 +255,12 @@ fn setup_ui(mut commands: Commands) {
     let style = TextStyle::default();
 
     commands.spawn(
-        TextBundle::from_sections(vec![
-            TextSection::new(String::new(), style.clone()),
-            TextSection::new(String::new(), style.clone()),
-            TextSection::new("1/2: -/+ shutter angle (blur amount)\n", style.clone()),
-            TextSection::new("3/4: -/+ sample count (blur quality)\n", style.clone()),
-            TextSection::new("Spacebar: cycle camera\n", style.clone()),
+        TextBundle::from_spans(vec![
+            TextSpan::new(String::new(), style.clone()),
+            TextSpan::new(String::new(), style.clone()),
+            TextSpan::new("1/2: -/+ shutter angle (blur amount)\n", style.clone()),
+            TextSpan::new("3/4: -/+ sample count (blur quality)\n", style.clone()),
+            TextSpan::new("Spacebar: cycle camera\n", style.clone()),
         ])
         .with_style(Style {
             position_type: PositionType::Absolute,
@@ -295,8 +295,8 @@ fn keyboard_inputs(
     settings.shutter_angle = settings.shutter_angle.clamp(0.0, 1.0);
     settings.samples = settings.samples.clamp(0, 64);
     let mut text = text.single_mut();
-    text.sections[0].value = format!("Shutter angle: {:.2}\n", settings.shutter_angle);
-    text.sections[1].value = format!("Samples: {:.5}\n", settings.samples);
+    text.spans[0].value = format!("Shutter angle: {:.2}\n", settings.shutter_angle);
+    text.spans[1].value = format!("Samples: {:.5}\n", settings.samples);
 }
 
 /// Parametric function for a looping race track. `offset` will return the point offset

--- a/examples/3d/parallax_mapping.rs
+++ b/examples/3d/parallax_mapping.rs
@@ -98,7 +98,7 @@ fn update_parallax_depth_scale(
             let current_depth = mat.parallax_depth_scale;
             let new_depth = current_depth.lerp(target_depth.0, DEPTH_CHANGE_RATE);
             mat.parallax_depth_scale = new_depth;
-            text.sections[0].value = format!("Parallax depth scale: {new_depth:.5}\n");
+            text.spans[0].value = format!("Parallax depth scale: {new_depth:.5}\n");
             if (new_depth - current_depth).abs() <= 0.000000001 {
                 *depth_update = false;
             }
@@ -118,7 +118,7 @@ fn switch_method(
         return;
     }
     let mut text = text.single_mut();
-    text.sections[2].value = format!("Method: {}\n", *current);
+    text.spans[2].value = format!("Method: {}\n", *current);
 
     for (_, mat) in materials.iter_mut() {
         mat.parallax_mapping_method = current.0;
@@ -141,7 +141,7 @@ fn update_parallax_layers(
     }
     let layer_count = target_layers.0.exp2();
     let mut text = text.single_mut();
-    text.sections[1].value = format!("Layers: {layer_count:.0}\n");
+    text.spans[1].value = format!("Layers: {layer_count:.0}\n");
 
     for (_, mat) in materials.iter_mut() {
         mat.max_parallax_layer_count = layer_count;
@@ -305,25 +305,25 @@ fn setup(
 
     // example instructions
     commands.spawn(
-        TextBundle::from_sections(vec![
-            TextSection::new(
+        TextBundle::from_spans(vec![
+            TextSpan::new(
                 format!("Parallax depth scale: {parallax_depth_scale:.5}\n"),
                 style.clone(),
             ),
-            TextSection::new(
+            TextSpan::new(
                 format!("Layers: {max_parallax_layer_count:.0}\n"),
                 style.clone(),
             ),
-            TextSection::new(format!("{parallax_mapping_method}\n"), style.clone()),
-            TextSection::new("\n\n", style.clone()),
-            TextSection::new("Controls:\n", style.clone()),
-            TextSection::new("Left click - Change view angle\n", style.clone()),
-            TextSection::new(
+            TextSpan::new(format!("{parallax_mapping_method}\n"), style.clone()),
+            TextSpan::new("\n\n", style.clone()),
+            TextSpan::new("Controls:\n", style.clone()),
+            TextSpan::new("Left click - Change view angle\n", style.clone()),
+            TextSpan::new(
                 "1/2 - Decrease/Increase parallax depth scale\n",
                 style.clone(),
             ),
-            TextSection::new("3/4 - Decrease/Increase layer count\n", style.clone()),
-            TextSection::new("Space - Switch parallaxing algorithm\n", style),
+            TextSpan::new("3/4 - Decrease/Increase layer count\n", style.clone()),
+            TextSpan::new("Space - Switch parallaxing algorithm\n", style),
         ])
         .with_style(Style {
             position_type: PositionType::Absolute,

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -62,7 +62,7 @@ fn setup(
 
     // labels
     commands.spawn(
-        TextBundle::from_section(
+        TextBundle::from_span(
             "Perceptual Roughness",
             TextStyle {
                 font_size: 36.0,
@@ -78,7 +78,7 @@ fn setup(
     );
 
     commands.spawn(TextBundle {
-        text: Text::from_section(
+        text: Text::from_span(
             "Metallic",
             TextStyle {
                 font_size: 36.0,
@@ -99,7 +99,7 @@ fn setup(
     });
 
     commands.spawn((
-        TextBundle::from_section(
+        TextBundle::from_span(
             "Loading Environment Map...",
             TextStyle {
                 font_size: 36.0,

--- a/examples/3d/reflection_probes.rs
+++ b/examples/3d/reflection_probes.rs
@@ -281,7 +281,7 @@ impl AppStatus {
             START_ROTATION_HELP_TEXT
         };
 
-        Text::from_section(
+        Text::from_span(
             format!(
                 "{}\n{}\n{}",
                 self.reflection_mode, rotation_help_text, REFLECTION_MODE_HELP_TEXT

--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -127,53 +127,53 @@ fn setup(
             ..default()
         })
         .with_children(|c| {
-            c.spawn(TextBundle::from_sections([
-                TextSection::new("Controls:\n", style.clone()),
-                TextSection::new("R / Z - reset biases to default / zero\n", style.clone()),
-                TextSection::new(
+            c.spawn(TextBundle::from_spans([
+                TextSpan::new("Controls:\n", style.clone()),
+                TextSpan::new("R / Z - reset biases to default / zero\n", style.clone()),
+                TextSpan::new(
                     "L     - switch between directional and point lights [",
                     style.clone(),
                 ),
-                TextSection::new("DirectionalLight", style.clone()),
-                TextSection::new("]\n", style.clone()),
-                TextSection::new(
+                TextSpan::new("DirectionalLight", style.clone()),
+                TextSpan::new("]\n", style.clone()),
+                TextSpan::new(
                     "F     - switch directional light filter methods [",
                     style.clone(),
                 ),
-                TextSection::new("Hardware2x2", style.clone()),
-                TextSection::new("]\n", style.clone()),
-                TextSection::new("1/2   - change point light depth bias [", style.clone()),
-                TextSection::new("0.00", style.clone()),
-                TextSection::new("]\n", style.clone()),
-                TextSection::new("3/4   - change point light normal bias [", style.clone()),
-                TextSection::new("0.0", style.clone()),
-                TextSection::new("]\n", style.clone()),
-                TextSection::new("5/6   - change direction light depth bias [", style.clone()),
-                TextSection::new("0.00", style.clone()),
-                TextSection::new("]\n", style.clone()),
-                TextSection::new(
+                TextSpan::new("Hardware2x2", style.clone()),
+                TextSpan::new("]\n", style.clone()),
+                TextSpan::new("1/2   - change point light depth bias [", style.clone()),
+                TextSpan::new("0.00", style.clone()),
+                TextSpan::new("]\n", style.clone()),
+                TextSpan::new("3/4   - change point light normal bias [", style.clone()),
+                TextSpan::new("0.0", style.clone()),
+                TextSpan::new("]\n", style.clone()),
+                TextSpan::new("5/6   - change direction light depth bias [", style.clone()),
+                TextSpan::new("0.00", style.clone()),
+                TextSpan::new("]\n", style.clone()),
+                TextSpan::new(
                     "7/8   - change direction light normal bias [",
                     style.clone(),
                 ),
-                TextSection::new("0.0", style.clone()),
-                TextSection::new("]\n", style.clone()),
-                TextSection::new(
+                TextSpan::new("0.0", style.clone()),
+                TextSpan::new("]\n", style.clone()),
+                TextSpan::new(
                     "left/right/up/down/pgup/pgdown - adjust light position (looking at 0,0,0) [",
                     style.clone(),
                 ),
-                TextSection::new(
+                TextSpan::new(
                     format!("{:.1},", light_transform.translation.x),
                     style.clone(),
                 ),
-                TextSection::new(
+                TextSpan::new(
                     format!(" {:.1},", light_transform.translation.y),
                     style.clone(),
                 ),
-                TextSection::new(
+                TextSpan::new(
                     format!(" {:.1}", light_transform.translation.z),
                     style.clone(),
                 ),
-                TextSection::new("]\n", style.clone()),
+                TextSpan::new("]\n", style.clone()),
             ]));
         });
 }
@@ -187,7 +187,7 @@ fn toggle_light(
     if input.just_pressed(KeyCode::KeyL) {
         for mut light in &mut point_lights {
             light.intensity = if light.intensity == 0.0 {
-                example_text.single_mut().sections[3].value = "PointLight".to_string();
+                example_text.single_mut().spans[3].value = "PointLight".to_string();
                 100000000.0
             } else {
                 0.0
@@ -195,7 +195,7 @@ fn toggle_light(
         }
         for mut light in &mut directional_lights {
             light.illuminance = if light.illuminance == 0.0 {
-                example_text.single_mut().sections[3].value = "DirectionalLight".to_string();
+                example_text.single_mut().spans[3].value = "DirectionalLight".to_string();
                 100000.0
             } else {
                 0.0
@@ -233,9 +233,9 @@ fn adjust_light_position(
         for mut light in &mut lights {
             light.translation += offset;
             light.look_at(Vec3::ZERO, Vec3::Y);
-            example_text.sections[21].value = format!("{:.1},", light.translation.x);
-            example_text.sections[22].value = format!(" {:.1},", light.translation.y);
-            example_text.sections[23].value = format!(" {:.1}", light.translation.z);
+            example_text.spans[21].value = format!("{:.1},", light.translation.x);
+            example_text.spans[22].value = format!(" {:.1},", light.translation.y);
+            example_text.spans[23].value = format!(" {:.1}", light.translation.z);
         }
     }
 }
@@ -262,7 +262,7 @@ fn cycle_filter_methods(
                     ShadowFilteringMethod::Hardware2x2
                 }
             };
-            example_text.single_mut().sections[6].value = filter_method_string;
+            example_text.single_mut().spans[6].value = filter_method_string;
         }
     }
 }
@@ -296,8 +296,8 @@ fn adjust_point_light_biases(
             light.shadow_normal_bias = 0.0;
         }
 
-        example_text.single_mut().sections[9].value = format!("{:.2}", light.shadow_depth_bias);
-        example_text.single_mut().sections[12].value = format!("{:.1}", light.shadow_normal_bias);
+        example_text.single_mut().spans[9].value = format!("{:.2}", light.shadow_depth_bias);
+        example_text.single_mut().spans[12].value = format!("{:.1}", light.shadow_normal_bias);
     }
 }
 
@@ -330,7 +330,7 @@ fn adjust_directional_light_biases(
             light.shadow_normal_bias = 0.0;
         }
 
-        example_text.single_mut().sections[15].value = format!("{:.2}", light.shadow_depth_bias);
-        example_text.single_mut().sections[18].value = format!("{:.1}", light.shadow_normal_bias);
+        example_text.single_mut().spans[15].value = format!("{:.2}", light.shadow_depth_bias);
+        example_text.single_mut().spans[18].value = format!("{:.1}", light.shadow_normal_bias);
     }
 }

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -99,7 +99,7 @@ fn setup(
                 },
             ))
             .with_children(|parent| {
-                parent.spawn(TextBundle::from_section(*camera_name, TextStyle::default()));
+                parent.spawn(TextBundle::from_span(*camera_name, TextStyle::default()));
                 buttons_panel(parent);
             });
     }
@@ -145,7 +145,7 @@ fn setup(
                 },
             ))
             .with_children(|parent| {
-                parent.spawn(TextBundle::from_section(caption, TextStyle::default()));
+                parent.spawn(TextBundle::from_span(caption, TextStyle::default()));
             });
     }
 }

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -137,7 +137,7 @@ fn setup(
     });
 
     commands.spawn(
-        TextBundle::from_section(INSTRUCTIONS, TextStyle::default()).with_style(Style {
+        TextBundle::from_span(INSTRUCTIONS, TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),
             left: Val::Px(12.0),

--- a/examples/3d/ssao.rs
+++ b/examples/3d/ssao.rs
@@ -93,7 +93,7 @@ fn setup(
     });
 
     commands.spawn(
-        TextBundle::from_section("", TextStyle::default()).with_style(Style {
+        TextBundle::from_span("", TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             bottom: Val::Px(12.0),
             left: Val::Px(12.0),
@@ -155,7 +155,7 @@ fn update(
     }
 
     let mut text = text.single_mut();
-    let text = &mut text.sections[0].value;
+    let text = &mut text.spans[0].value;
     text.clear();
 
     let (o, l, m, h, u) = match ssao_settings.map(|s| s.quality_level) {

--- a/examples/3d/ssr.rs
+++ b/examples/3d/ssr.rs
@@ -269,7 +269,7 @@ fn spawn_text(commands: &mut Commands, app_settings: &AppSettings) {
 
 // Creates or recreates the help text.
 fn create_text(app_settings: &AppSettings) -> Text {
-    Text::from_section(
+    Text::from_span(
         format!(
             "{}\n{}\n{}",
             match app_settings.displayed_model {

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -83,7 +83,7 @@ fn setup(
 
     // ui
     commands.spawn(
-        TextBundle::from_section("", TextStyle::default()).with_style(Style {
+        TextBundle::from_span("", TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),
             left: Val::Px(12.0),
@@ -190,7 +190,7 @@ fn setup_image_viewer_scene(
 
     commands
         .spawn((
-            TextBundle::from_section(
+            TextBundle::from_span(
                 "Drag and drop an HDR or EXR file",
                 TextStyle {
                     font_size: 36.0,
@@ -422,13 +422,13 @@ fn update_ui(
         *hide_ui = !*hide_ui;
     }
 
-    let old_text = &text_query.single().sections[0].value;
+    let old_text = &text_query.single().spans[0].value;
 
     if *hide_ui {
         if !old_text.is_empty() {
             // single_mut() always triggers change detection,
             // so only access if text actually needs changing
-            text_query.single_mut().sections[0].value.clear();
+            text_query.single_mut().spans[0].value.clear();
         }
         return;
     }
@@ -545,7 +545,7 @@ fn update_ui(
     if text != old_text.as_str() {
         // single_mut() always triggers change detection,
         // so only access if text actually changed
-        text_query.single_mut().sections[0].value = text;
+        text_query.single_mut().spans[0].value = text;
     }
 }
 

--- a/examples/3d/transmission.rs
+++ b/examples/3d/transmission.rs
@@ -368,7 +368,7 @@ fn setup(
     let text_style = TextStyle::default();
 
     commands.spawn((
-        TextBundle::from_section("", text_style).with_style(Style {
+        TextBundle::from_span("", text_style).with_style(Style {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),
             left: Val::Px(12.0),
@@ -585,7 +585,7 @@ fn example_control_system(
     );
 
     let mut display = display.single_mut();
-    display.sections[0].value = format!(
+    display.spans[0].value = format!(
         concat!(
             " J / K / L / ;  Screen Space Specular Transmissive Quality: {:?}\n",
             "         O / P  Screen Space Specular Transmissive Steps: {}\n",

--- a/examples/3d/visibility_range.rs
+++ b/examples/3d/visibility_range.rs
@@ -303,7 +303,7 @@ fn update_help_text(mut text_query: Query<&mut Text>, app_status: Res<AppStatus>
 impl AppStatus {
     // Creates and returns help text reflecting the app status.
     fn create_text(&self) -> Text {
-        Text::from_section(
+        Text::from_span(
             format!(
                 "\
 {} (1) Switch from high-poly to low-poly based on camera distance

--- a/examples/3d/volumetric_fog.rs
+++ b/examples/3d/volumetric_fog.rs
@@ -62,7 +62,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Add the help text.
     commands.spawn(
         TextBundle {
-            text: Text::from_section(
+            text: Text::from_span(
                 "Press WASD or the arrow keys to change the light direction",
                 TextStyle::default(),
             ),

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -113,7 +113,7 @@ fn setup(
 
     // Text used to show controls
     commands.spawn(
-        TextBundle::from_section("", TextStyle::default()).with_style(Style {
+        TextBundle::from_span("", TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),
             left: Val::Px(12.0),
@@ -129,7 +129,7 @@ fn update_colors(
     mut wireframe_colors: Query<&mut WireframeColor, With<Wireframe>>,
     mut text: Query<&mut Text>,
 ) {
-    text.single_mut().sections[0].value = format!(
+    text.single_mut().spans[0].value = format!(
         "Controls
 ---------------
 Z - Toggle global

--- a/examples/animation/animation_graph.rs
+++ b/examples/animation/animation_graph.rs
@@ -254,7 +254,7 @@ fn setup_scene(
 /// Places the help text at the top left of the window.
 fn setup_help_text(commands: &mut Commands) {
     commands.spawn(TextBundle {
-        text: Text::from_section(HELP_TEXT, TextStyle::default()),
+        text: Text::from_span(HELP_TEXT, TextStyle::default()),
         style: Style {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),
@@ -275,7 +275,7 @@ fn setup_node_rects(commands: &mut Commands) {
 
         let text = commands
             .spawn(TextBundle {
-                text: Text::from_section(
+                text: Text::from_span(
                     node_string,
                     TextStyle {
                         font_size: 16.0,
@@ -447,7 +447,7 @@ fn update_ui(
             // Update the node labels with the current weights.
             let mut text_iter = text_query.iter_many_mut(children);
             if let Some(mut text) = text_iter.fetch_next() {
-                text.sections[0].value = format!(
+                text.spans[0].value = format!(
                     "{}\n{:.2}",
                     clip_node.text, animation_weights.weights[clip_node.index]
                 );

--- a/examples/app/log_layers_ecs.rs
+++ b/examples/app/log_layers_ecs.rs
@@ -142,10 +142,7 @@ fn print_logs(
 
     commands.entity(root_entity).with_children(|child| {
         for event in events.read() {
-            child.spawn(TextBundle::from_section(
-                &event.message,
-                TextStyle::default(),
-            ));
+            child.spawn(TextBundle::from_span(&event.message, TextStyle::default()));
         }
     });
 }

--- a/examples/app/logs.rs
+++ b/examples/app/logs.rs
@@ -21,7 +21,7 @@ fn main() {
 fn setup(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
     commands.spawn(TextBundle {
-        text: Text::from_section("Press P to panic", TextStyle::default()),
+        text: Text::from_span("Press P to panic", TextStyle::default()),
         style: Style {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),

--- a/examples/asset/multi_asset_sync.rs
+++ b/examples/asset/multi_asset_sync.rs
@@ -182,7 +182,7 @@ fn setup_ui(mut commands: Commands) {
             b.spawn((
                 TextBundle {
                     text: Text {
-                        sections: vec![TextSection {
+                        spans: vec![TextSpan {
                             value: "Loading...".to_owned(),
                             style: TextStyle {
                                 font_size: 64.0,
@@ -287,7 +287,7 @@ fn get_async_loading_state(
     if is_loaded {
         next_loading_state.set(LoadingState::Loaded);
         if let Ok(mut text) = text.get_single_mut() {
-            "Loaded!".clone_into(&mut text.sections[0].value);
+            "Loaded!".clone_into(&mut text.spans[0].value);
         }
     }
 }

--- a/examples/async_tasks/external_source_external_thread.rs
+++ b/examples/async_tasks/external_source_external_thread.rs
@@ -58,7 +58,7 @@ fn spawn_text(mut commands: Commands, mut reader: EventReader<StreamEvent>) {
 
     for (per_frame, event) in reader.read().enumerate() {
         commands.spawn(Text2dBundle {
-            text: Text::from_section(event.0.to_string(), text_style.clone())
+            text: Text::from_span(event.0.to_string(), text_style.clone())
                 .with_justify(JustifyText::Center),
             transform: Transform::from_xyz(per_frame as f32 * 100.0, 300.0, 0.0),
             ..default()

--- a/examples/audio/spatial_audio_2d.rs
+++ b/examples/audio/spatial_audio_2d.rs
@@ -76,7 +76,7 @@ fn setup(
 
     // example instructions
     commands.spawn(
-        TextBundle::from_section(
+        TextBundle::from_span(
             "Up/Down/Left/Right: Move Listener\nSpace: Toggle Emitter Movement",
             TextStyle::default(),
         )

--- a/examples/audio/spatial_audio_3d.rs
+++ b/examples/audio/spatial_audio_3d.rs
@@ -66,7 +66,7 @@ fn setup(
 
     // example instructions
     commands.spawn(
-        TextBundle::from_section(
+        TextBundle::from_span(
             "Up/Down/Left/Right: Move Listener\nSpace: Toggle Emitter Movement",
             TextStyle::default(),
         )

--- a/examples/camera/2d_top_down_camera.rs
+++ b/examples/camera/2d_top_down_camera.rs
@@ -60,7 +60,7 @@ fn setup_scene(
 
 fn setup_instructions(mut commands: Commands) {
     commands.spawn(
-        TextBundle::from_section(
+        TextBundle::from_span(
             "Move the light with ZQSD or WASD.\nThe camera will smoothly track the light.",
             TextStyle::default(),
         )

--- a/examples/camera/first_person_view_model.rs
+++ b/examples/camera/first_person_view_model.rs
@@ -204,7 +204,7 @@ fn spawn_text(mut commands: Commands) {
             ..default()
         })
         .with_children(|parent| {
-            parent.spawn(TextBundle::from_section(
+            parent.spawn(TextBundle::from_span(
                 concat!(
                     "Move the camera with your mouse.\n",
                     "Press arrow up to decrease the FOV of the world model.\n",

--- a/examples/dev_tools/fps_overlay.rs
+++ b/examples/dev_tools/fps_overlay.rs
@@ -44,7 +44,7 @@ fn setup(mut commands: Commands) {
             ..default()
         })
         .with_children(|c| {
-            c.spawn(TextBundle::from_section(
+            c.spawn(TextBundle::from_span(
                 concat!(
                     "Press 1 to change color of the overlay.\n",
                     "Press 2 to change size of the overlay."

--- a/examples/ecs/observers.rs
+++ b/examples/ecs/observers.rs
@@ -72,7 +72,7 @@ struct Explode;
 fn setup(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
     commands.spawn(
-        TextBundle::from_section(
+        TextBundle::from_span(
             "Click on a \"Mine\" to trigger it.\n\
             When it explodes it will trigger all overlapping mines.",
             TextStyle {

--- a/examples/ecs/one_shot_systems.rs
+++ b/examples/ecs/one_shot_systems.rs
@@ -81,29 +81,29 @@ fn evaluate_callbacks(query: Query<(Entity, &Callback), With<Triggered>>, mut co
 
 fn system_a(mut query: Query<&mut Text>) {
     let mut text = query.single_mut();
-    text.sections[2].value = String::from("A");
+    text.spans[2].value = String::from("A");
     info!("A: One shot system registered with Commands was triggered");
 }
 
 fn system_b(mut query: Query<&mut Text>) {
     let mut text = query.single_mut();
-    text.sections[2].value = String::from("B");
+    text.spans[2].value = String::from("B");
     info!("B: One shot system registered with World was triggered");
 }
 
 fn setup_ui(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
     commands.spawn(
-        TextBundle::from_sections([
-            TextSection::new(
+        TextBundle::from_spans([
+            TextSpan::new(
                 "Press A or B to trigger a one-shot system\n",
                 TextStyle {
                     font_size: 25.0,
                     ..default()
                 },
             ),
-            TextSection::new("Last Triggered: ", TextStyle::default()),
-            TextSection::new(
+            TextSpan::new("Last Triggered: ", TextStyle::default()),
+            TextSpan::new(
                 "-",
                 TextStyle {
                     color: bevy::color::palettes::css::ORANGE.into(),

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -177,7 +177,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
 
     // scoreboard
     commands.spawn(
-        TextBundle::from_section(
+        TextBundle::from_span(
             "Score:",
             TextStyle {
                 font_size: 40.0,
@@ -385,7 +385,7 @@ fn rotate_bonus(game: Res<Game>, time: Res<Time>, mut transforms: Query<&mut Tra
 // update the score displayed during the game
 fn scoreboard_system(game: Res<Game>, mut query: Query<&mut Text>) {
     let mut text = query.single_mut();
-    text.sections[0].value = format!("Sugar Rush: {}", game.score);
+    text.spans[0].value = format!("Sugar Rush: {}", game.score);
 }
 
 // restart the game when pressing spacebar
@@ -411,7 +411,7 @@ fn display_score(mut commands: Commands, game: Res<Game>) {
             ..default()
         })
         .with_children(|parent| {
-            parent.spawn(TextBundle::from_section(
+            parent.spawn(TextBundle::from_span(
                 format!("Cake eaten: {}", game.cake_eaten),
                 TextStyle {
                     font_size: 80.0,

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -233,8 +233,8 @@ fn setup(
     // Scoreboard
     commands.spawn((
         ScoreboardUi,
-        TextBundle::from_sections([
-            TextSection::new(
+        TextBundle::from_spans([
+            TextSpan::new(
                 "Score: ",
                 TextStyle {
                     font_size: SCOREBOARD_FONT_SIZE,
@@ -242,7 +242,7 @@ fn setup(
                     ..default()
                 },
             ),
-            TextSection::from_style(TextStyle {
+            TextSpan::from_style(TextStyle {
                 font_size: SCOREBOARD_FONT_SIZE,
                 color: SCORE_COLOR,
                 ..default()
@@ -354,7 +354,7 @@ fn apply_velocity(mut query: Query<(&mut Transform, &Velocity)>, time: Res<Time>
 
 fn update_scoreboard(score: Res<Score>, mut query: Query<&mut Text, With<ScoreboardUi>>) {
     let mut text = query.single_mut();
-    text.sections[1].value = score.to_string();
+    text.spans[1].value = score.to_string();
 }
 
 fn check_for_collisions(

--- a/examples/games/contributors.rs
+++ b/examples/games/contributors.rs
@@ -138,9 +138,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     };
 
     commands.spawn((
-        TextBundle::from_sections([
-            TextSection::new("Contributor showcase", text_style.clone()),
-            TextSection::from_style(TextStyle {
+        TextBundle::from_spans([
+            TextSpan::new("Contributor showcase", text_style.clone()),
+            TextSpan::from_style(TextStyle {
                 font_size: 30.,
                 ..text_style
             }),
@@ -202,13 +202,13 @@ fn select(
 
     transform.translation.z = 100.0;
 
-    text.sections[0].value.clone_from(&contributor.name);
-    text.sections[1].value = format!(
+    text.spans[0].value.clone_from(&contributor.name);
+    text.spans[1].value = format!(
         "\n{} commit{}",
         contributor.num_commits,
         if contributor.num_commits > 1 { "s" } else { "" }
     );
-    text.sections[0].style.color = sprite.color;
+    text.spans[0].style.color = sprite.color;
 }
 
 /// Change the tint color to the "deselected" color and push

--- a/examples/games/desk_toy.rs
+++ b/examples/games/desk_toy.rs
@@ -115,7 +115,7 @@ fn setup(
     };
     commands.spawn((
         Text2dBundle {
-            text: Text::from_section(
+            text: Text::from_span(
                 "Press Space to play on your desktop! Press it again to return.\nRight click Bevy logo to exit.",
                 text_style.clone(),
             ),

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -176,7 +176,7 @@ mod game {
                     .with_children(|parent| {
                         // Display two lines of text, the second one with the current settings
                         parent.spawn(
-                            TextBundle::from_section(
+                            TextBundle::from_span(
                                 "Will be back to the menu shortly...",
                                 TextStyle {
                                     font_size: 80.0,
@@ -190,8 +190,8 @@ mod game {
                             }),
                         );
                         parent.spawn(
-                            TextBundle::from_sections([
-                                TextSection::new(
+                            TextBundle::from_spans([
+                                TextSpan::new(
                                     format!("quality: {:?}", *display_quality),
                                     TextStyle {
                                         font_size: 60.0,
@@ -199,7 +199,7 @@ mod game {
                                         ..default()
                                     },
                                 ),
-                                TextSection::new(
+                                TextSpan::new(
                                     " - ",
                                     TextStyle {
                                         font_size: 60.0,
@@ -207,7 +207,7 @@ mod game {
                                         ..default()
                                     },
                                 ),
-                                TextSection::new(
+                                TextSpan::new(
                                     format!("volume: {:?}", *volume),
                                     TextStyle {
                                         font_size: 60.0,
@@ -434,7 +434,7 @@ mod menu {
                     .with_children(|parent| {
                         // Display the game name
                         parent.spawn(
-                            TextBundle::from_section(
+                            TextBundle::from_span(
                                 "Bevy Game Menu UI",
                                 TextStyle {
                                     font_size: 80.0,
@@ -468,7 +468,7 @@ mod menu {
                                     image: UiImage::new(icon),
                                     ..default()
                                 });
-                                parent.spawn(TextBundle::from_section(
+                                parent.spawn(TextBundle::from_span(
                                     "New Game",
                                     button_text_style.clone(),
                                 ));
@@ -489,7 +489,7 @@ mod menu {
                                     image: UiImage::new(icon),
                                     ..default()
                                 });
-                                parent.spawn(TextBundle::from_section(
+                                parent.spawn(TextBundle::from_span(
                                     "Settings",
                                     button_text_style.clone(),
                                 ));
@@ -510,7 +510,7 @@ mod menu {
                                     image: UiImage::new(icon),
                                     ..default()
                                 });
-                                parent.spawn(TextBundle::from_section("Quit", button_text_style));
+                                parent.spawn(TextBundle::from_span("Quit", button_text_style));
                             });
                     });
             });
@@ -573,7 +573,7 @@ mod menu {
                                     action,
                                 ))
                                 .with_children(|parent| {
-                                    parent.spawn(TextBundle::from_section(
+                                    parent.spawn(TextBundle::from_span(
                                         text,
                                         button_text_style.clone(),
                                     ));
@@ -637,7 +637,7 @@ mod menu {
                             })
                             .with_children(|parent| {
                                 // Display a label for the current setting
-                                parent.spawn(TextBundle::from_section(
+                                parent.spawn(TextBundle::from_span(
                                     "Display Quality",
                                     button_text_style.clone(),
                                 ));
@@ -660,7 +660,7 @@ mod menu {
                                         quality_setting,
                                     ));
                                     entity.with_children(|parent| {
-                                        parent.spawn(TextBundle::from_section(
+                                        parent.spawn(TextBundle::from_span(
                                             format!("{quality_setting:?}"),
                                             button_text_style.clone(),
                                         ));
@@ -681,7 +681,7 @@ mod menu {
                                 MenuButtonAction::BackToSettings,
                             ))
                             .with_children(|parent| {
-                                parent.spawn(TextBundle::from_section("Back", button_text_style));
+                                parent.spawn(TextBundle::from_span("Back", button_text_style));
                             });
                     });
             });
@@ -738,7 +738,7 @@ mod menu {
                                 ..default()
                             })
                             .with_children(|parent| {
-                                parent.spawn(TextBundle::from_section(
+                                parent.spawn(TextBundle::from_span(
                                     "Volume",
                                     button_text_style.clone(),
                                 ));
@@ -770,7 +770,7 @@ mod menu {
                                 MenuButtonAction::BackToSettings,
                             ))
                             .with_children(|parent| {
-                                parent.spawn(TextBundle::from_section("Back", button_text_style));
+                                parent.spawn(TextBundle::from_span("Back", button_text_style));
                             });
                     });
             });

--- a/examples/games/loading_screen.rs
+++ b/examples/games/loading_screen.rs
@@ -92,7 +92,7 @@ fn setup(mut commands: Commands) {
             ..default()
         })
         .with_children(|parent| {
-            parent.spawn(TextBundle::from_section(
+            parent.spawn(TextBundle::from_span(
                 "Press 1 or 2 to load a new scene.",
                 text_style,
             ));
@@ -299,7 +299,7 @@ fn load_loading_screen(mut commands: Commands) {
             LoadingScreen,
         ))
         .with_children(|parent| {
-            parent.spawn(TextBundle::from_sections([TextSection::new(
+            parent.spawn(TextBundle::from_spans([TextSpan::new(
                 "Loading...",
                 text_style.clone(),
             )]));

--- a/examples/games/stepping.rs
+++ b/examples/games/stepping.rs
@@ -103,7 +103,7 @@ fn build_ui(
     mut stepping: ResMut<Stepping>,
     mut state: ResMut<State>,
 ) {
-    let mut text_sections = Vec::new();
+    let mut text_spans = Vec::new();
     let mut always_run = Vec::new();
 
     let Ok(schedule_order) = stepping.schedules() else {
@@ -114,7 +114,7 @@ fn build_ui(
     // each label
     for label in schedule_order {
         let schedule = schedules.get(*label).unwrap();
-        text_sections.push(TextSection::new(
+        text_spans.push(TextSpan::new(
             format!("{:?}\n", label),
             TextStyle {
                 font: asset_server.load(FONT_BOLD),
@@ -138,10 +138,10 @@ fn build_ui(
 
             // Add an entry to our systems list so we can find where to draw
             // the cursor when the stepping cursor is at this system
-            state.systems.push((*label, node_id, text_sections.len()));
+            state.systems.push((*label, node_id, text_spans.len()));
 
-            // Add a text section for displaying the cursor for this system
-            text_sections.push(TextSection::new(
+            // Add a text span for displaying the cursor for this system
+            text_spans.push(TextSpan::new(
                 "   ",
                 TextStyle {
                     color: FONT_COLOR,
@@ -150,7 +150,7 @@ fn build_ui(
             ));
 
             // add the name of the system to the ui
-            text_sections.push(TextSection::new(
+            text_spans.push(TextSpan::new(
                 format!("{}\n", system.name()),
                 TextStyle {
                     color: FONT_COLOR,
@@ -167,7 +167,7 @@ fn build_ui(
     commands.spawn((
         SteppingUi,
         TextBundle {
-            text: Text::from_sections(text_sections),
+            text: Text::from_spans(text_spans),
             style: Style {
                 position_type: PositionType::Absolute,
                 top: state.ui_top,
@@ -190,7 +190,7 @@ fn build_stepping_hint(mut commands: Commands) {
     };
     info!("{}", hint_text);
     // stepping description box
-    commands.spawn((TextBundle::from_sections([TextSection::new(
+    commands.spawn((TextBundle::from_spans([TextSpan::new(
         hint_text,
         TextStyle {
             font_size: 18.0,
@@ -274,6 +274,6 @@ fn update_ui(
         } else {
             "   "
         };
-        text.sections[*text_index].value = mark.to_string();
+        text.spans[*text_index].value = mark.to_string();
     }
 }

--- a/examples/gizmos/2d_gizmos.rs
+++ b/examples/gizmos/2d_gizmos.rs
@@ -21,7 +21,7 @@ fn setup(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
     // text
     commands.spawn(
-        TextBundle::from_section(
+        TextBundle::from_span(
             "Hold 'Left' or 'Right' to change the line width of straight gizmos\n\
         Hold 'Up' or 'Down' to change the line width of round gizmos\n\
         Press '1' / '2' to toggle the visibility of straight / round gizmos\n\

--- a/examples/gizmos/3d_gizmos.rs
+++ b/examples/gizmos/3d_gizmos.rs
@@ -52,7 +52,7 @@ fn setup(
 
     // example instructions
     commands.spawn(
-        TextBundle::from_section(
+        TextBundle::from_span(
             "Press 'D' to toggle drawing gizmos on top of everything else in the scene\n\
             Press 'P' to toggle perspective for line gizmos\n\
             Hold 'Left' or 'Right' to change the line width of straight gizmos\n\

--- a/examples/gizmos/light_gizmos.rs
+++ b/examples/gizmos/light_gizmos.rs
@@ -110,7 +110,7 @@ fn setup(
         let text_style = TextStyle::default();
 
         commands.spawn(
-            TextBundle::from_section(
+            TextBundle::from_span(
                 "Press 'D' to toggle drawing gizmos on top of everything else in the scene\n\
             Hold 'Left' or 'Right' to change the line width of the gizmos\n\
             Press 'A' to toggle drawing of the light gizmos\n\
@@ -130,9 +130,9 @@ fn setup(
         light_config.color = LightGizmoColor::MatchLightColor;
 
         commands.spawn((
-            TextBundle::from_sections([
-                TextSection::new("Gizmo color mode: ", text_style.clone()),
-                TextSection::new(gizmo_color_text(light_config), text_style),
+            TextBundle::from_spans([
+                TextSpan::new("Gizmo color mode: ", text_style.clone()),
+                TextSpan::new(gizmo_color_text(light_config), text_style),
             ])
             .with_style(Style {
                 position_type: PositionType::Absolute,
@@ -182,6 +182,6 @@ fn update_config(
             LightGizmoColor::MatchLightColor => LightGizmoColor::ByLightType,
             LightGizmoColor::ByLightType => LightGizmoColor::Manual(GRAY.into()),
         };
-        color_text_query.single_mut().sections[1].value = gizmo_color_text(light_config);
+        color_text_query.single_mut().spans[1].value = gizmo_color_text(light_config);
     }
 }

--- a/examples/input/text_input.rs
+++ b/examples/input/text_input.rs
@@ -36,15 +36,15 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
     let font = asset_server.load("fonts/FiraMono-Medium.ttf");
 
     commands.spawn(
-        TextBundle::from_sections([
-            TextSection {
+        TextBundle::from_spans([
+            TextSpan {
                 value: "IME Enabled: ".to_string(),
                 style: TextStyle {
                     font: font.clone_weak(),
                     ..default()
                 },
             },
-            TextSection {
+            TextSpan {
                 value: "false\n".to_string(),
                 style: TextStyle {
                     font: font.clone_weak(),
@@ -52,14 +52,14 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
                     ..default()
                 },
             },
-            TextSection {
+            TextSpan {
                 value: "IME Active: ".to_string(),
                 style: TextStyle {
                     font: font.clone_weak(),
                     ..default()
                 },
             },
-            TextSection {
+            TextSpan {
                 value: "false\n".to_string(),
                 style: TextStyle {
                     font: font.clone_weak(),
@@ -67,7 +67,7 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
                     ..default()
                 },
             },
-            TextSection {
+            TextSpan {
                 value: "click to toggle IME, press return to start a new line\n\n".to_string(),
                 style: TextStyle {
                     font: font.clone_weak(),
@@ -75,7 +75,7 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
                     ..default()
                 },
             },
-            TextSection {
+            TextSpan {
                 value: "".to_string(),
                 style: TextStyle {
                     font,
@@ -93,7 +93,7 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     commands.spawn(Text2dBundle {
-        text: Text::from_section(
+        text: Text::from_span(
             "".to_string(),
             TextStyle {
                 font: asset_server.load("fonts/FiraMono-Medium.ttf"),
@@ -117,7 +117,7 @@ fn toggle_ime(
         window.ime_enabled = !window.ime_enabled;
 
         let mut text = text.single_mut();
-        text.sections[1].value = format!("{}\n", window.ime_enabled);
+        text.spans[1].value = format!("{}\n", window.ime_enabled);
     }
 }
 
@@ -147,19 +147,19 @@ fn listen_ime_events(
     for event in events.read() {
         match event {
             Ime::Preedit { value, cursor, .. } if !cursor.is_none() => {
-                status_text.single_mut().sections[5].value = format!("IME buffer: {value}");
+                status_text.single_mut().spans[5].value = format!("IME buffer: {value}");
             }
             Ime::Preedit { cursor, .. } if cursor.is_none() => {
-                status_text.single_mut().sections[5].value = "".to_string();
+                status_text.single_mut().spans[5].value = "".to_string();
             }
             Ime::Commit { value, .. } => {
-                edit_text.single_mut().sections[0].value.push_str(value);
+                edit_text.single_mut().spans[0].value.push_str(value);
             }
             Ime::Enabled { .. } => {
-                status_text.single_mut().sections[3].value = "true\n".to_string();
+                status_text.single_mut().spans[3].value = "true\n".to_string();
             }
             Ime::Disabled { .. } => {
-                status_text.single_mut().sections[3].value = "false\n".to_string();
+                status_text.single_mut().spans[3].value = "false\n".to_string();
             }
             _ => (),
         }
@@ -180,14 +180,14 @@ fn listen_keyboard_input_events(
         match &event.logical_key {
             Key::Enter => {
                 let mut text = edit_text.single_mut();
-                if text.sections[0].value.is_empty() {
+                if text.spans[0].value.is_empty() {
                     continue;
                 }
-                let old_value = mem::take(&mut text.sections[0].value);
+                let old_value = mem::take(&mut text.spans[0].value);
 
                 commands.spawn((
                     Text2dBundle {
-                        text: Text::from_section(old_value, text.sections[0].style.clone()),
+                        text: Text::from_span(old_value, text.spans[0].style.clone()),
                         ..default()
                     },
                     Bubble {
@@ -196,13 +196,13 @@ fn listen_keyboard_input_events(
                 ));
             }
             Key::Space => {
-                edit_text.single_mut().sections[0].value.push(' ');
+                edit_text.single_mut().spans[0].value.push(' ');
             }
             Key::Backspace => {
-                edit_text.single_mut().sections[0].value.pop();
+                edit_text.single_mut().spans[0].value.pop();
             }
             Key::Character(character) => {
-                edit_text.single_mut().sections[0].value.push_str(character);
+                edit_text.single_mut().spans[0].value.push_str(character);
             }
             _ => continue,
         }

--- a/examples/math/custom_primitives.rs
+++ b/examples/math/custom_primitives.rs
@@ -167,7 +167,7 @@ fn setup(
 
     // Example instructions
     commands.spawn(
-        TextBundle::from_section(
+        TextBundle::from_span(
             "Press 'B' to toggle between no bounding shapes, bounding boxes (AABBs) and bounding spheres / circles\n\
             Press 'Space' to switch between 3D and 2D",
             TextStyle::default(),

--- a/examples/math/random_sampling.rs
+++ b/examples/math/random_sampling.rs
@@ -113,7 +113,7 @@ fn setup(
 
     // Instructions for the example:
     commands.spawn(
-        TextBundle::from_section(
+        TextBundle::from_span(
             "Controls:\n\
             M: Toggle between sampling boundary and interior.\n\
             R: Restart (erase all samples).\n\

--- a/examples/math/render_primitives.rs
+++ b/examples/math/render_primitives.rs
@@ -378,12 +378,12 @@ fn setup_text(mut commands: Commands, cameras: Query<(Entity, &Camera)>) {
     let instructions = "Press 'C' to switch between 2D and 3D mode\n\
         Press 'Up' or 'Down' to switch to the next/previous primitive";
     let text = [
-        TextSection::new("Primitive: ", style.clone()),
-        TextSection::new(text, style.clone()),
-        TextSection::new("\n\n", style.clone()),
-        TextSection::new(instructions, style.clone()),
-        TextSection::new("\n\n", style.clone()),
-        TextSection::new(
+        TextSpan::new("Primitive: ", style.clone()),
+        TextSpan::new(text, style.clone()),
+        TextSpan::new("\n\n", style.clone()),
+        TextSpan::new(instructions, style.clone()),
+        TextSpan::new("\n\n", style.clone()),
+        TextSpan::new(
             "(If nothing is displayed, there's no rendering support yet)",
             style.clone(),
         ),
@@ -405,7 +405,7 @@ fn setup_text(mut commands: Commands, cameras: Query<(Entity, &Camera)>) {
         .with_children(|parent| {
             parent.spawn((
                 HeaderText,
-                TextBundle::from_sections(text).with_text_justify(JustifyText::Center),
+                TextBundle::from_spans(text).with_text_justify(JustifyText::Center),
             ));
         });
 }
@@ -416,7 +416,7 @@ fn update_text(
 ) {
     let new_text = format!("{text}", text = primitive_state.get());
     header.iter_mut().for_each(|mut header_text| {
-        if let Some(kind) = header_text.sections.get_mut(1) {
+        if let Some(kind) = header_text.spans.get_mut(1) {
             kind.value.clone_from(&new_text);
         };
     });

--- a/examples/math/sampling_primitives.rs
+++ b/examples/math/sampling_primitives.rs
@@ -385,7 +385,7 @@ fn setup(
 
     // Instructions for the example:
     commands.spawn(
-        TextBundle::from_section(
+        TextBundle::from_span(
             "Controls:\n\
             M: Toggle between sampling boundary and interior.\n\
             A: Toggle automatic spawning & despawning of points.\n\

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -132,7 +132,7 @@ fn setup_scene(
         ))
         .with_children(|b| {
             b.spawn(
-                TextBundle::from_section(
+                TextBundle::from_span(
                     "Test Button",
                     TextStyle {
                         font_size: 30.0,

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -150,7 +150,7 @@ fn save_scene_system(world: &mut World) {
 fn infotext_system(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
     commands.spawn(
-        TextBundle::from_section(
+        TextBundle::from_span(
             "Nothing to see in this window! Check the console output!",
             TextStyle {
                 font_size: 50.0,

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -139,12 +139,12 @@ fn setup(
     let style = TextStyle::default();
 
     commands.spawn(
-        TextBundle::from_sections(vec![
-            TextSection::new("Prepass Output: transparent\n", style.clone()),
-            TextSection::new("\n\n", style.clone()),
-            TextSection::new("Controls\n", style.clone()),
-            TextSection::new("---------------\n", style.clone()),
-            TextSection::new("Space - Change output\n", style),
+        TextBundle::from_spans(vec![
+            TextSpan::new("Prepass Output: transparent\n", style.clone()),
+            TextSpan::new("\n\n", style.clone()),
+            TextSpan::new("Controls\n", style.clone()),
+            TextSpan::new("---------------\n", style.clone()),
+            TextSpan::new("Space - Change output\n", style),
         ])
         .with_style(Style {
             position_type: PositionType::Absolute,
@@ -240,9 +240,9 @@ fn toggle_prepass_view(
             _ => unreachable!(),
         };
         let mut text = text.single_mut();
-        text.sections[0].value = format!("Prepass Output: {label}\n");
-        for section in &mut text.sections {
-            section.style.color = Color::WHITE;
+        text.spans[0].value = format!("Prepass Output: {label}\n");
+        for span in &mut text.spans {
+            span.style.color = Color::WHITE;
         }
 
         let handle = material_handle.single();

--- a/examples/state/computed_states.rs
+++ b/examples/state/computed_states.rs
@@ -369,7 +369,7 @@ mod ui {
                         MenuButton::Play,
                     ))
                     .with_children(|parent| {
-                        parent.spawn(TextBundle::from_section(
+                        parent.spawn(TextBundle::from_span(
                             "Play",
                             TextStyle {
                                 font_size: 40.0,
@@ -400,7 +400,7 @@ mod ui {
                         MenuButton::Tutorial,
                     ))
                     .with_children(|parent| {
-                        parent.spawn(TextBundle::from_section(
+                        parent.spawn(TextBundle::from_span(
                             "Tutorial",
                             TextStyle {
                                 font_size: 40.0,
@@ -501,7 +501,7 @@ mod ui {
                         MenuButton::Play,
                     ))
                     .with_children(|parent| {
-                        parent.spawn(TextBundle::from_section(
+                        parent.spawn(TextBundle::from_span(
                             "Paused",
                             TextStyle {
                                 font_size: 40.0,
@@ -533,7 +533,7 @@ mod ui {
                 },
             ))
             .with_children(|parent| {
-                parent.spawn(TextBundle::from_section(
+                parent.spawn(TextBundle::from_span(
                     "TURBO MODE",
                     TextStyle {
                         font_size: 40.0,
@@ -575,7 +575,7 @@ mod ui {
                 },
             ))
             .with_children(|parent| {
-                parent.spawn(TextBundle::from_section(
+                parent.spawn(TextBundle::from_span(
                     "Move the bevy logo with the arrow keys",
                     TextStyle {
                         font_size: 40.0,
@@ -583,7 +583,7 @@ mod ui {
                         ..default()
                     },
                 ));
-                parent.spawn(TextBundle::from_section(
+                parent.spawn(TextBundle::from_span(
                     "Press T to enter TURBO MODE",
                     TextStyle {
                         font_size: 40.0,
@@ -592,7 +592,7 @@ mod ui {
                     },
                 ));
 
-                parent.spawn(TextBundle::from_section(
+                parent.spawn(TextBundle::from_span(
                     "Press SPACE to pause",
                     TextStyle {
                         font_size: 40.0,
@@ -601,7 +601,7 @@ mod ui {
                     },
                 ));
 
-                parent.spawn(TextBundle::from_section(
+                parent.spawn(TextBundle::from_span(
                     "Press ESCAPE to return to the menu",
                     TextStyle {
                         font_size: 40.0,
@@ -632,7 +632,7 @@ mod ui {
                 },
             ))
             .with_children(|parent| {
-                parent.spawn(TextBundle::from_section(
+                parent.spawn(TextBundle::from_span(
                     "Press SPACE to resume",
                     TextStyle {
                         font_size: 40.0,
@@ -641,7 +641,7 @@ mod ui {
                     },
                 ));
 
-                parent.spawn(TextBundle::from_section(
+                parent.spawn(TextBundle::from_span(
                     "Press ESCAPE to return to the menu",
                     TextStyle {
                         font_size: 40.0,

--- a/examples/state/custom_transitions.rs
+++ b/examples/state/custom_transitions.rs
@@ -269,7 +269,7 @@ fn setup_menu(mut commands: Commands) {
                     ..default()
                 })
                 .with_children(|parent| {
-                    parent.spawn(TextBundle::from_section(
+                    parent.spawn(TextBundle::from_span(
                         "Play",
                         TextStyle {
                             font_size: 40.0,

--- a/examples/state/states.rs
+++ b/examples/state/states.rs
@@ -78,7 +78,7 @@ fn setup_menu(mut commands: Commands) {
                     ..default()
                 })
                 .with_children(|parent| {
-                    parent.spawn(TextBundle::from_section(
+                    parent.spawn(TextBundle::from_span(
                         "Play",
                         TextStyle {
                             font_size: 40.0,

--- a/examples/state/sub_states.rs
+++ b/examples/state/sub_states.rs
@@ -184,7 +184,7 @@ mod ui {
                         ..default()
                     })
                     .with_children(|parent| {
-                        parent.spawn(TextBundle::from_section(
+                        parent.spawn(TextBundle::from_span(
                             "Play",
                             TextStyle {
                                 font_size: 40.0,
@@ -239,7 +239,7 @@ mod ui {
                         ..default()
                     })
                     .with_children(|parent| {
-                        parent.spawn(TextBundle::from_section(
+                        parent.spawn(TextBundle::from_span(
                             "Paused",
                             TextStyle {
                                 font_size: 40.0,

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -230,8 +230,8 @@ fn setup(
         transform_rng: ChaCha8Rng::seed_from_u64(42),
     };
 
-    let text_section = move |color: Srgba, value: &str| {
-        TextSection::new(
+    let text_span = move |color: Srgba, value: &str| {
+        TextSpan::new(
             value,
             TextStyle {
                 font_size: 40.0,
@@ -255,15 +255,15 @@ fn setup(
         })
         .with_children(|c| {
             c.spawn((
-                TextBundle::from_sections([
-                    text_section(LIME, "Bird Count: "),
-                    text_section(AQUA, ""),
-                    text_section(LIME, "\nFPS (raw): "),
-                    text_section(AQUA, ""),
-                    text_section(LIME, "\nFPS (SMA): "),
-                    text_section(AQUA, ""),
-                    text_section(LIME, "\nFPS (EMA): "),
-                    text_section(AQUA, ""),
+                TextBundle::from_spans([
+                    text_span(LIME, "Bird Count: "),
+                    text_span(AQUA, ""),
+                    text_span(LIME, "\nFPS (raw): "),
+                    text_span(AQUA, ""),
+                    text_span(LIME, "\nFPS (SMA): "),
+                    text_span(AQUA, ""),
+                    text_span(LIME, "\nFPS (EMA): "),
+                    text_span(AQUA, ""),
                 ]),
                 StatsText,
             ));
@@ -525,18 +525,18 @@ fn counter_system(
     let mut text = query.single_mut();
 
     if counter.is_changed() {
-        text.sections[1].value = counter.count.to_string();
+        text.spans[1].value = counter.count.to_string();
     }
 
     if let Some(fps) = diagnostics.get(&FrameTimeDiagnosticsPlugin::FPS) {
         if let Some(raw) = fps.value() {
-            text.sections[3].value = format!("{raw:.2}");
+            text.spans[3].value = format!("{raw:.2}");
         }
         if let Some(sma) = fps.average() {
-            text.sections[5].value = format!("{sma:.2}");
+            text.spans[5].value = format!("{sma:.2}");
         }
         if let Some(ema) = fps.smoothed() {
-            text.sections[7].value = format!("{ema:.2}");
+            text.spans[7].value = format!("{ema:.2}");
         }
     };
 }

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -259,7 +259,7 @@ fn spawn_button(
 
     if spawn_text {
         builder.with_children(|parent| {
-            parent.spawn(TextBundle::from_section(
+            parent.spawn(TextBundle::from_span(
                 format!("{column}, {row}"),
                 TextStyle {
                     font_size: FONT_SIZE,

--- a/examples/stress_tests/many_gizmos.rs
+++ b/examples/stress_tests/many_gizmos.rs
@@ -88,7 +88,7 @@ fn setup(mut commands: Commands) {
     });
 
     commands.spawn(
-        TextBundle::from_section("", TextStyle::default()).with_style(Style {
+        TextBundle::from_span("", TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),
             left: Val::Px(12.0),
@@ -107,7 +107,7 @@ fn ui_system(mut query: Query<&mut Text>, config: Res<Config>, diag: Res<Diagnos
         return;
     };
 
-    text.sections[0].value = format!(
+    text.spans[0].value = format!(
         "Line count: {}\n\
         FPS: {:.0}\n\n\
         Controls:\n\

--- a/examples/stress_tests/many_glyphs.rs
+++ b/examples/stress_tests/many_glyphs.rs
@@ -1,6 +1,6 @@
 //! Simple text rendering benchmark.
 //!
-//! Creates a `Text` with a single `TextSection` containing `100_000` glyphs,
+//! Creates a `Text` with a single `TextSpan` containing `100_000` glyphs,
 //! and renders it with the UI in a white color and with Text2d in a red color.
 //!
 //! To recompute all text each frame run
@@ -46,7 +46,7 @@ fn setup(mut commands: Commands) {
 
     commands.spawn(Camera2dBundle::default());
     let mut text = Text {
-        sections: vec![TextSection {
+        spans: vec![TextSpan {
             value: "0123456789".repeat(10_000),
             style: TextStyle {
                 font_size: 4.,
@@ -78,7 +78,7 @@ fn setup(mut commands: Commands) {
             });
         });
 
-    text.sections[0].style.color = RED.into();
+    text.spans[0].style.color = RED.into();
 
     commands.spawn(Text2dBundle {
         text,

--- a/examples/stress_tests/text_pipeline.rs
+++ b/examples/stress_tests/text_pipeline.rs
@@ -1,6 +1,6 @@
 //! Text pipeline benchmark.
 //!
-//! Continuously recomputes a large `Text` component with 100 sections.
+//! Continuously recomputes a large `Text` component with 100 spans.
 
 use bevy::{
     color::palettes::basic::{BLUE, YELLOW},
@@ -39,10 +39,10 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
     warn!(include_str!("warning_string.txt"));
 
     commands.spawn(Camera2dBundle::default());
-    let sections = (1..=50)
+    let spans = (1..=50)
         .flat_map(|i| {
             [
-                TextSection {
+                TextSpan {
                     value: "text".repeat(i),
                     style: TextStyle {
                         font: asset_server.load("fonts/FiraMono-Medium.ttf"),
@@ -50,7 +50,7 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
                         color: BLUE.into(),
                     },
                 },
-                TextSection {
+                TextSpan {
                     value: "pipeline".repeat(i),
                     style: TextStyle {
                         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
@@ -63,7 +63,7 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
         .collect::<Vec<_>>();
     commands.spawn(Text2dBundle {
         text: Text {
-            sections,
+            spans,
             justify: JustifyText::Center,
             linebreak_behavior: BreakLineOn::AnyCharacter,
         },

--- a/examples/time/virtual_time.rs
+++ b/examples/time/virtual_time.rs
@@ -98,7 +98,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut time: ResMu
         .with_children(|builder| {
             // real time info
             builder.spawn((
-                TextBundle::from_section(
+                TextBundle::from_span(
                     "",
                     TextStyle {
                         font_size,
@@ -110,7 +110,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut time: ResMu
 
             // keybindings
             builder.spawn(
-                TextBundle::from_section(
+                TextBundle::from_span(
                     "CONTROLS\nUn/Pause: Space\nSpeed+: Up\nSpeed-: Down",
                     TextStyle {
                         font_size,
@@ -123,7 +123,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut time: ResMu
 
             // virtual time info
             builder.spawn((
-                TextBundle::from_section(
+                TextBundle::from_span(
                     "",
                     TextStyle {
                         font_size,
@@ -194,7 +194,7 @@ fn toggle_pause(mut time: ResMut<Time<Virtual>>) {
 /// Update the `Real` time info text
 fn update_real_time_info_text(time: Res<Time<Real>>, mut query: Query<&mut Text, With<RealTime>>) {
     for mut text in &mut query {
-        text.sections[0].value = format!(
+        text.spans[0].value = format!(
             "REAL TIME\nElapsed: {:.1}\nDelta: {:.5}\n",
             time.elapsed_seconds(),
             time.delta_seconds(),
@@ -208,7 +208,7 @@ fn update_virtual_time_info_text(
     mut query: Query<&mut Text, With<VirtualTime>>,
 ) {
     for mut text in &mut query {
-        text.sections[0].value = format!(
+        text.spans[0].value = format!(
             "VIRTUAL TIME\nElapsed: {:.1}\nDelta: {:.5}\nSpeed: {:.2}",
             time.elapsed_seconds(),
             time.delta_seconds(),

--- a/examples/tools/gamepad_viewer.rs
+++ b/examples/tools/gamepad_viewer.rs
@@ -317,16 +317,16 @@ fn setup_sticks(
                 parent.spawn((
                     Text2dBundle {
                         transform: Transform::from_xyz(0., STICK_BOUNDS_SIZE + 2., 4.),
-                        text: Text::from_sections([
-                            TextSection {
+                        text: Text::from_spans([
+                            TextSpan {
                                 value: format!("{:.3}", 0.),
                                 style: style.clone(),
                             },
-                            TextSection {
+                            TextSpan {
                                 value: ", ".to_string(),
                                 style: style.clone(),
                             },
-                            TextSection {
+                            TextSpan {
                                 value: format!("{:.3}", 0.),
                                 style,
                             },
@@ -389,7 +389,7 @@ fn setup_triggers(
                 parent.spawn((
                     Text2dBundle {
                         transform: Transform::from_xyz(0., 0., 1.),
-                        text: Text::from_section(
+                        text: Text::from_span(
                             format!("{:.3}", 0.),
                             TextStyle {
                                 font_size: 16.,
@@ -420,12 +420,12 @@ fn setup_connected(mut commands: Commands) {
 
     commands.spawn((
         TextBundle {
-            text: Text::from_sections([
-                TextSection {
+            text: Text::from_spans([
+                TextSpan {
                     value: "Connected Gamepads:\n".to_string(),
                     style: text_style.clone(),
                 },
-                TextSection {
+                TextSpan {
                     value: "None".to_string(),
                     style: text_style,
                 },
@@ -467,7 +467,7 @@ fn update_button_values(
     for button_event in events.read() {
         for (mut text, text_with_button_value) in query.iter_mut() {
             if button_event.button_type == **text_with_button_value {
-                text.sections[0].value = format!("{:.3}", button_event.value);
+                text.spans[0].value = format!("{:.3}", button_event.value);
             }
         }
     }
@@ -491,10 +491,10 @@ fn update_axes(
         }
         for (mut text, text_with_axes) in text_query.iter_mut() {
             if axis_type == text_with_axes.x_axis {
-                text.sections[0].value = format!("{value:.3}");
+                text.spans[0].value = format!("{value:.3}");
             }
             if axis_type == text_with_axes.y_axis {
-                text.sections[2].value = format!("{value:.3}");
+                text.spans[2].value = format!("{value:.3}");
             }
         }
     }
@@ -516,7 +516,7 @@ fn update_connected(
         .collect::<Vec<_>>()
         .join("\n");
 
-    text.sections[1].value = if !formatted.is_empty() {
+    text.spans[1].value = if !formatted.is_empty() {
         formatted
     } else {
         "None".to_string()

--- a/examples/tools/scene_viewer/morph_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/morph_viewer_plugin.rs
@@ -122,8 +122,8 @@ impl fmt::Display for Target {
     }
 }
 impl Target {
-    fn text_section(&self, key: &str, style: TextStyle) -> TextSection {
-        TextSection::new(format!("[{key}] {self}\n"), style)
+    fn text_span(&self, key: &str, style: TextStyle) -> TextSpan {
+        TextSpan::new(format!("[{key}] {self}\n"), style)
     }
     fn new(
         entity_name: Option<&Name>,
@@ -196,7 +196,7 @@ fn update_text(
         }
         let key_name = &AVAILABLE_KEYS[i].name;
         let mut text = text.single_mut();
-        text.sections[i + 2].value = format!("[{key_name}] {target}\n");
+        text.spans[i + 2].value = format!("[{key_name}] {target}\n");
     }
 }
 fn update_morphs(
@@ -257,15 +257,15 @@ fn detect_morphs(
         font_size: 13.0,
         ..default()
     };
-    let mut sections = vec![
-        TextSection::new("Morph Target Controls\n", style.clone()),
-        TextSection::new("---------------\n", style.clone()),
+    let mut spans = vec![
+        TextSpan::new("Morph Target Controls\n", style.clone()),
+        TextSpan::new("---------------\n", style.clone()),
     ];
     let target_to_text =
-        |(i, target): (usize, &Target)| target.text_section(AVAILABLE_KEYS[i].name, style.clone());
-    sections.extend(detected.iter().enumerate().map(target_to_text));
+        |(i, target): (usize, &Target)| target.text_span(AVAILABLE_KEYS[i].name, style.clone());
+    spans.extend(detected.iter().enumerate().map(target_to_text));
     commands.insert_resource(WeightsControl { weights: detected });
-    commands.spawn(TextBundle::from_sections(sections).with_style(Style {
+    commands.spawn(TextBundle::from_spans(spans).with_style(Style {
         position_type: PositionType::Absolute,
         top: Val::Px(10.0),
         left: Val::Px(10.0),

--- a/examples/transforms/align.rs
+++ b/examples/transforms/align.rs
@@ -99,7 +99,7 @@ fn setup(
 
     // Instructions for the example
     commands.spawn((
-        TextBundle::from_section(
+        TextBundle::from_span(
             "The bright red axis is the primary alignment axis, and it will always be\n\
             made to coincide with the primary target direction (white) exactly.\n\
             The fainter red axis is the secondary alignment axis, and it is made to\n\

--- a/examples/ui/borders.rs
+++ b/examples/ui/borders.rs
@@ -142,7 +142,7 @@ fn setup(mut commands: Commands) {
             .add_child(inner_spot)
             .id();
         let label_node = commands
-            .spawn(TextBundle::from_section(
+            .spawn(TextBundle::from_span(
                 label,
                 TextStyle {
                     font_size: 9.0,

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -28,17 +28,17 @@ fn button_system(
         let mut text = text_query.get_mut(children[0]).unwrap();
         match *interaction {
             Interaction::Pressed => {
-                text.sections[0].value = "Press".to_string();
+                text.spans[0].value = "Press".to_string();
                 image.color = PRESSED_BUTTON;
                 border_color.0 = RED.into();
             }
             Interaction::Hovered => {
-                text.sections[0].value = "Hover".to_string();
+                text.spans[0].value = "Hover".to_string();
                 image.color = HOVERED_BUTTON;
                 border_color.0 = Color::WHITE;
             }
             Interaction::None => {
-                text.sections[0].value = "Button".to_string();
+                text.spans[0].value = "Button".to_string();
                 image.color = NORMAL_BUTTON;
                 border_color.0 = Color::BLACK;
             }
@@ -79,7 +79,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     ..default()
                 })
                 .with_children(|parent| {
-                    parent.spawn(TextBundle::from_section(
+                    parent.spawn(TextBundle::from_span(
                         "Button",
                         TextStyle {
                             font: asset_server.load("fonts/FiraSans-Bold.ttf"),

--- a/examples/ui/display_and_visibility.rs
+++ b/examples/ui/display_and_visibility.rs
@@ -96,7 +96,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         ..Default::default()
     }).with_children(|parent| {
         parent.spawn(TextBundle {
-            text: Text::from_section(
+            text: Text::from_span(
                 "Use the panel on the right to change the Display and Visibility properties for the respective nodes of the panel on the left",                
                 text_style.clone(),
             ).with_justify(JustifyText::Center),
@@ -157,20 +157,20 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 };
 
                 builder.spawn(TextBundle {
-                    text: Text::from_section(
+                    text: Text::from_span(
                         "Display::None\nVisibility::Hidden\nVisibility::Inherited",
                         TextStyle { color: HIDDEN_COLOR, ..text_style.clone() }
                         ).with_justify(JustifyText::Center),
                     ..Default::default()
                     });
                     builder.spawn(TextBundle {
-                        text: Text::from_section(
+                        text: Text::from_span(
                             "-\n-\n-",
                             TextStyle { color: DARK_GRAY.into(), ..text_style.clone() }
                             ).with_justify(JustifyText::Center),
                         ..Default::default()
                         });
-                    builder.spawn(TextBundle::from_section(
+                    builder.spawn(TextBundle::from_span(
                         "The UI Node and its descendants will not be visible and will not be allotted any space in the UI layout.\nThe UI Node will not be visible but will still occupy space in the UI layout.\nThe UI node will inherit the visibility property of its parent. If it has no parent it will be visible.",
                         text_style
                     ));
@@ -423,7 +423,7 @@ where
         ))
         .with_children(|builder| {
             builder.spawn(
-                TextBundle::from_section(
+                TextBundle::from_span(
                     format!("{}::{:?}", Target::<T>::NAME, T::default()),
                     text_style,
                 )
@@ -445,9 +445,9 @@ fn buttons_handler<T>(
             let mut target_value = left_panel_query.get_mut(target.id).unwrap();
             for &child in children {
                 if let Ok(mut text) = text_query.get_mut(child) {
-                    text.sections[0].value = target.update_target(target_value.as_mut());
-                    text.sections[0].style.color = if text.sections[0].value.contains("None")
-                        || text.sections[0].value.contains("Hidden")
+                    text.spans[0].value = target.update_target(target_value.as_mut());
+                    text.spans[0].style.color = if text.spans[0].value.contains("None")
+                        || text.spans[0].value.contains("Hidden")
                     {
                         Color::srgb(1.0, 0.7, 0.7)
                     } else {
@@ -470,7 +470,7 @@ fn text_hover(
                 for &child in children {
                     if let Ok(mut text) = text_query.get_mut(child) {
                         // Bypass change detection to avoid recomputation of the text when only changing the color
-                        text.bypass_change_detection().sections[0].style.color = YELLOW.into();
+                        text.bypass_change_detection().spans[0].style.color = YELLOW.into();
                     }
                 }
             }
@@ -478,9 +478,9 @@ fn text_hover(
                 image.color = Color::BLACK.with_alpha(0.5);
                 for &child in children {
                     if let Ok(mut text) = text_query.get_mut(child) {
-                        text.bypass_change_detection().sections[0].style.color =
-                            if text.sections[0].value.contains("None")
-                                || text.sections[0].value.contains("Hidden")
+                        text.bypass_change_detection().spans[0].style.color =
+                            if text.spans[0].value.contains("None")
+                                || text.spans[0].value.contains("Hidden")
                             {
                                 HIDDEN_COLOR
                             } else {

--- a/examples/ui/flex_layout.rs
+++ b/examples/ui/flex_layout.rs
@@ -173,7 +173,7 @@ fn spawn_nested_text_bundle(
             ..Default::default()
         })
         .with_children(|builder| {
-            builder.spawn(TextBundle::from_section(
+            builder.spawn(TextBundle::from_span(
                 text,
                 TextStyle {
                     font,

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -71,7 +71,7 @@ fn text_update_system(
     if state.timer.tick(time.delta()).finished() {
         for mut text in &mut query {
             let c = seeded_rng.gen::<u8>() as char;
-            let string = &mut text.sections[0].value;
+            let string = &mut text.spans[0].value;
             if !string.contains(c) {
                 string.push(c);
             }
@@ -96,7 +96,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut state: ResM
             ..default()
         })
         .with_children(|parent| {
-            parent.spawn(TextBundle::from_section(
+            parent.spawn(TextBundle::from_span(
                 "a",
                 TextStyle {
                     font: font_handle,

--- a/examples/ui/grid.rs
+++ b/examples/ui/grid.rs
@@ -136,7 +136,7 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
                     ..default()
                 })
                 .with_children(|builder| {
-                    builder.spawn(TextBundle::from_section(
+                    builder.spawn(TextBundle::from_span(
                         "Sidebar",
                         TextStyle {
                             font: font.clone(),
@@ -144,7 +144,7 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
                             ..default()
                         },
                     ));
-                    builder.spawn(TextBundle::from_section(
+                    builder.spawn(TextBundle::from_span(
                         "A paragraph of text which ought to wrap nicely. A paragraph of text which ought to wrap nicely. A paragraph of text which ought to wrap nicely. A paragraph of text which ought to wrap nicely. A paragraph of text which ought to wrap nicely. A paragraph of text which ought to wrap nicely. A paragraph of text which ought to wrap nicely.",
                         TextStyle {
                             font: font.clone(),
@@ -211,7 +211,7 @@ fn item_rect(builder: &mut ChildBuilder, color: Srgba) {
 }
 
 fn spawn_nested_text_bundle(builder: &mut ChildBuilder, font: Handle<Font>, text: &str) {
-    builder.spawn(TextBundle::from_section(
+    builder.spawn(TextBundle::from_span(
         text,
         TextStyle {
             font,

--- a/examples/ui/overflow.rs
+++ b/examples/ui/overflow.rs
@@ -62,7 +62,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             })
                             .with_children(|parent| {
                                 parent.spawn(TextBundle {
-                                    text: Text::from_section(label, text_style.clone()),
+                                    text: Text::from_span(label, text_style.clone()),
                                     ..Default::default()
                                 });
                             });

--- a/examples/ui/overflow_debug.rs
+++ b/examples/ui/overflow_debug.rs
@@ -82,12 +82,12 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let text_style = TextStyle::default();
 
     commands.spawn((
-        TextBundle::from_sections([
-            TextSection::new(
+        TextBundle::from_spans([
+            TextSpan::new(
                 "Next Overflow Setting (O)\nNext Container Size (S)\nToggle Animation (space)\n\n",
                 text_style.clone(),
             ),
-            TextSection::new(format!("{:?}", Overflow::clip()), text_style.clone()),
+            TextSpan::new(format!("{:?}", Overflow::clip()), text_style.clone()),
         ])
         .with_style(Style {
             position_type: PositionType::Absolute,
@@ -162,7 +162,7 @@ fn spawn_text(
     update_transform: impl UpdateTransform + Component,
 ) {
     spawn_container(parent, update_transform, |parent| {
-        parent.spawn(TextBundle::from_section(
+        parent.spawn(TextBundle::from_span(
             "Bevy",
             TextStyle {
                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),
@@ -274,7 +274,7 @@ fn toggle_overflow(
         };
 
         let mut text = instructions.single_mut();
-        text.sections[1].value = format!("{:?}", style.overflow);
+        text.spans[1].value = format!("{:?}", style.overflow);
     }
 }
 

--- a/examples/ui/relative_cursor_position.rs
+++ b/examples/ui/relative_cursor_position.rs
@@ -55,7 +55,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 .insert(RelativeCursorPosition::default());
 
             parent.spawn(TextBundle {
-                text: Text::from_section(
+                text: Text::from_span(
                     "(0.0, 0.0)",
                     TextStyle {
                         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
@@ -77,7 +77,7 @@ fn relative_cursor_position_system(
 
     let mut output = output_query.single_mut();
 
-    output.sections[0].value =
+    output.spans[0].value =
         if let Some(relative_cursor_position) = relative_cursor_position.normalized {
             format!(
                 "({:.1}, {:.1})",
@@ -87,7 +87,7 @@ fn relative_cursor_position_system(
             "unknown".to_string()
         };
 
-    output.sections[0].style.color = if relative_cursor_position.mouse_over() {
+    output.spans[0].style.color = if relative_cursor_position.mouse_over() {
         Color::srgb(0.1, 0.9, 0.1)
     } else {
         Color::srgb(0.9, 0.1, 0.1)

--- a/examples/ui/render_ui_to_texture.rs
+++ b/examples/ui/render_ui_to_texture.rs
@@ -92,7 +92,7 @@ fn setup(
             TargetCamera(texture_camera),
         ))
         .with_children(|parent| {
-            parent.spawn(TextBundle::from_section(
+            parent.spawn(TextBundle::from_span(
                 "This is a cube",
                 TextStyle {
                     font_size: 40.0,

--- a/examples/ui/rounded_borders.rs
+++ b/examples/ui/rounded_borders.rs
@@ -152,7 +152,7 @@ fn setup(mut commands: Commands) {
             .add_child(inner_spot)
             .id();
         let label_node = commands
-            .spawn(TextBundle::from_section(
+            .spawn(TextBundle::from_span(
                 label,
                 TextStyle {
                     font_size: 9.0,

--- a/examples/ui/size_constraints.rs
+++ b/examples/ui/size_constraints.rs
@@ -73,7 +73,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 })
                 .with_children(|parent| {
                     parent.spawn(
-                        TextBundle::from_section("Size Constraints Example", text_style.clone())
+                        TextBundle::from_span("Size Constraints Example", text_style.clone())
                             .with_style(Style {
                                 margin: UiRect::bottom(Val::Px(25.)),
                                 ..Default::default()
@@ -193,7 +193,7 @@ fn spawn_button_row(parent: &mut ChildBuilder, constraint: Constraint, text_styl
                         })
                         .with_children(|parent| {
                             parent.spawn(TextBundle {
-                                text: Text::from_section(label.to_string(), text_style.clone()),
+                                text: Text::from_span(label.to_string(), text_style.clone()),
                                 ..Default::default()
                             });
                         });
@@ -273,7 +273,7 @@ fn spawn_button(
                 })
                 .with_children(|parent| {
                     parent.spawn(TextBundle {
-                        text: Text::from_section(
+                        text: Text::from_span(
                             label,
                             TextStyle {
                                 color: if active {
@@ -327,8 +327,8 @@ fn update_buttons(
                         if let Ok(grand_children) = children_query.get(child) {
                             for &grandchild in grand_children {
                                 if let Ok(mut text) = text_query.get_mut(grandchild) {
-                                    if text.sections[0].style.color != ACTIVE_TEXT_COLOR {
-                                        text.sections[0].style.color = HOVERED_TEXT_COLOR;
+                                    if text.spans[0].style.color != ACTIVE_TEXT_COLOR {
+                                        text.spans[0].style.color = HOVERED_TEXT_COLOR;
                                     }
                                 }
                             }
@@ -342,8 +342,8 @@ fn update_buttons(
                         if let Ok(grand_children) = children_query.get(child) {
                             for &grandchild in grand_children {
                                 if let Ok(mut text) = text_query.get_mut(grandchild) {
-                                    if text.sections[0].style.color != ACTIVE_TEXT_COLOR {
-                                        text.sections[0].style.color = UNHOVERED_TEXT_COLOR;
+                                    if text.spans[0].style.color != ACTIVE_TEXT_COLOR {
+                                        text.spans[0].style.color = UNHOVERED_TEXT_COLOR;
                                     }
                                 }
                             }
@@ -386,7 +386,7 @@ fn update_radio_buttons_colors(
                     color_query.get_mut(child).unwrap().0 = inner_color;
                     for &grandchild in children_query.get(child).into_iter().flatten() {
                         if let Ok(mut text) = text_query.get_mut(grandchild) {
-                            text.sections[0].style.color = text_color;
+                            text.spans[0].style.color = text_color;
                         }
                     }
                 }

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -28,10 +28,10 @@ struct ColorText;
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // UI camera
     commands.spawn(Camera2dBundle::default());
-    // Text with one section
+    // Text with one span
     commands.spawn((
-        // Create a TextBundle that has a Text with a single section.
-        TextBundle::from_section(
+        // Create a TextBundle that has a Text with a single span.
+        TextBundle::from_span(
             // Accepts a `String` or any type that converts into a `String`, such as `&str`
             "hello\nbevy!",
             TextStyle {
@@ -52,11 +52,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         ColorText,
     ));
 
-    // Text with multiple sections
+    // Text with multiple spans
     commands.spawn((
-        // Create a TextBundle that has a Text with a list of sections.
-        TextBundle::from_sections([
-            TextSection::new(
+        // Create a TextBundle that has a Text with a list of spans.
+        TextBundle::from_spans([
+            TextSpan::new(
                 "FPS: ",
                 TextStyle {
                     // This font is loaded and will be used instead of the default font.
@@ -65,7 +65,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     ..default()
                 },
             ),
-            TextSection::from_style(if cfg!(feature = "default_font") {
+            TextSpan::from_style(if cfg!(feature = "default_font") {
                 TextStyle {
                     font_size: 40.0,
                     color: GOLD.into(),
@@ -86,7 +86,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     #[cfg(feature = "default_font")]
     commands.spawn(
-        // Here we are able to call the `From` method instead of creating a new `TextSection`.
+        // Here we are able to call the `From` method instead of creating a new `TextSpan`.
         // This will use the default font (a minimal subset of FiraMono) and apply the default styling.
         TextBundle::from("From an &str into a TextBundle with the default font!").with_style(
             Style {
@@ -100,7 +100,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     #[cfg(not(feature = "default_font"))]
     commands.spawn(
-        TextBundle::from_section(
+        TextBundle::from_span(
             "Default font disabled",
             TextStyle {
                 font: asset_server.load("fonts/FiraMono-Medium.ttf"),
@@ -120,8 +120,8 @@ fn text_color_system(time: Res<Time>, mut query: Query<&mut Text, With<ColorText
     for mut text in &mut query {
         let seconds = time.elapsed_seconds();
 
-        // Update the color of the first and only section.
-        text.sections[0].style.color = Color::srgb(
+        // Update the color of the first and only span.
+        text.spans[0].style.color = Color::srgb(
             (1.25 * seconds).sin() / 2.0 + 0.5,
             (0.75 * seconds).sin() / 2.0 + 0.5,
             (0.50 * seconds).sin() / 2.0 + 0.5,
@@ -136,8 +136,8 @@ fn text_update_system(
     for mut text in &mut query {
         if let Some(fps) = diagnostics.get(&FrameTimeDiagnosticsPlugin::FPS) {
             if let Some(value) = fps.smoothed() {
-                // Update the value of the second section
-                text.sections[1].value = format!("{value:.2}");
+                // Update the value of the second span
+                text.spans[1].value = format!("{value:.2}");
             }
         }
     }

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -54,7 +54,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         ..default()
     }).with_children(|builder| {
         builder.spawn(
-            TextBundle::from_section(
+            TextBundle::from_span(
                 "This is\ntext with\nline breaks\nin the top left.",
                 TextStyle {
                     font: font.clone(),
@@ -63,7 +63,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 },
             )
         );
-        builder.spawn(TextBundle::from_section(
+        builder.spawn(TextBundle::from_span(
                 "This text is right-justified. The `JustifyText` component controls the horizontal alignment of the lines of multi-line text relative to each other, and does not affect the text node's position in the UI layout.",                TextStyle {
                     font: font.clone(),
                     font_size: 30.0,
@@ -77,7 +77,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
             })
         );
         builder.spawn(
-            TextBundle::from_section(
+            TextBundle::from_span(
                 "This\ntext has\nline breaks and also a set width in the bottom left.",
                 TextStyle {
                     font: font.clone(),
@@ -104,7 +104,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         ..default()
     }).with_children(|builder| {
 
-        builder.spawn(TextBundle::from_section(
+        builder.spawn(TextBundle::from_span(
                 "This text is very long, has a limited width, is center-justified, is positioned in the top right and is also colored pink.",
                 TextStyle {
                     font: font.clone(),
@@ -120,7 +120,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         );
 
         builder.spawn(
-            TextBundle::from_section(
+            TextBundle::from_span(
                 "This text is left-justified and is vertically positioned to distribute the empty space equally above and below it.",
                 TextStyle {
                     font: font.clone(),
@@ -136,8 +136,8 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         );
 
         builder.spawn((
-            TextBundle::from_sections([
-                TextSection::new(
+            TextBundle::from_spans([
+                TextSpan::new(
                     "This text changes in the bottom right",
                     TextStyle {
                         font: font.clone(),
@@ -145,7 +145,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                         ..default()
                     },
                 ),
-                TextSection::new(
+                TextSpan::new(
                     " this text has zero fontsize",
                     TextStyle {
                         font: font.clone(),
@@ -153,7 +153,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                         color: BLUE.into(),
                     },
                 ),
-                TextSection::new(
+                TextSpan::new(
                     "\nThis text changes in the bottom right - ",
                     TextStyle {
                         font: font.clone(),
@@ -161,12 +161,12 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                         color: RED.into(),
                     },
                 ),
-                TextSection::from_style(TextStyle {
+                TextSpan::from_style(TextStyle {
                     font: font.clone(),
                     font_size: 25.0,
                     color: ORANGE_RED.into(),
                 }),
-                TextSection::new(
+                TextSpan::new(
                     " fps, ",
                     TextStyle {
                         font: font.clone(),
@@ -174,12 +174,12 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                         color: YELLOW.into(),
                     },
                 ),
-                TextSection::from_style(TextStyle {
+                TextSpan::from_style(TextStyle {
                     font: font.clone(),
                     font_size: 25.0,
                     color: LIME.into(),
                 }),
-                TextSection::new(
+                TextSpan::new(
                     " ms/frame",
                     TextStyle {
                         font: font.clone(),
@@ -187,7 +187,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                         color: BLUE.into(),
                     },
                 ),
-                TextSection::new(
+                TextSpan::new(
                     " this text has negative fontsize",
                     TextStyle {
                         font: font.clone(),
@@ -228,12 +228,12 @@ fn change_text_system(
             }
         }
 
-        text.sections[0].value = format!(
+        text.spans[0].value = format!(
             "This text changes in the bottom right - {fps:.1} fps, {frame_time:.3} ms/frame",
         );
 
-        text.sections[3].value = format!("{fps:.1}");
+        text.spans[3].value = format!("{fps:.1}");
 
-        text.sections[5].value = format!("{frame_time:.3}");
+        text.spans[5].value = format!("{frame_time:.3}");
     }
 }

--- a/examples/ui/text_wrap_debug.rs
+++ b/examples/ui/text_wrap_debug.rs
@@ -121,7 +121,7 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
 
             for (j, message) in messages.into_iter().enumerate() {
                 let text = Text {
-                    sections: vec![TextSection {
+                    spans: vec![TextSpan {
                         value: message.clone(),
                         style: text_style.clone(),
                     }],

--- a/examples/ui/transparency_ui.rs
+++ b/examples/ui/transparency_ui.rs
@@ -41,7 +41,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     ..default()
                 })
                 .with_children(|parent| {
-                    parent.spawn(TextBundle::from_section(
+                    parent.spawn(TextBundle::from_span(
                         "Button 1",
                         TextStyle {
                             font: font_handle.clone(),
@@ -67,7 +67,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     ..default()
                 })
                 .with_children(|parent| {
-                    parent.spawn(TextBundle::from_section(
+                    parent.spawn(TextBundle::from_span(
                         "Button 2",
                         TextStyle {
                             font: font_handle.clone(),

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -72,7 +72,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         .with_children(|parent| {
                             // text
                             parent.spawn((
-                                TextBundle::from_section(
+                                TextBundle::from_span(
                                     "Text Example",
                                     TextStyle {
                                         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
@@ -89,7 +89,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             #[cfg(feature = "bevy_dev_tools")]
                             // Debug overlay text
                             parent.spawn((
-                                TextBundle::from_section(
+                                TextBundle::from_span(
                                     "Press Space to enable debug outlines.",
                                     TextStyle {
                                         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
@@ -101,7 +101,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
                             #[cfg(not(feature = "bevy_dev_tools"))]
                             parent.spawn((
-                                TextBundle::from_section(
+                                TextBundle::from_span(
                                     "Try enabling feature \"bevy_dev_tools\".",
                                     TextStyle {
                                         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
@@ -128,7 +128,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 .with_children(|parent| {
                     // Title
                     parent.spawn((
-                        TextBundle::from_section(
+                        TextBundle::from_span(
                             "Scrolling list",
                             TextStyle {
                                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),
@@ -170,7 +170,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     // List items
                                     for i in 0..30 {
                                         parent.spawn((
-                                            TextBundle::from_section(
+                                            TextBundle::from_span(
                                                 format!("Item {i}"),
                                                 TextStyle {
                                                     font: asset_server
@@ -329,7 +329,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     },
                                     ..Default::default()
                                 },
-                                Text::from_section("Bevy logo", TextStyle::default()),
+                                Text::from_span("Bevy logo", TextStyle::default()),
                             ));
                         });
                 });

--- a/examples/ui/ui_scaling.rs
+++ b/examples/ui/ui_scaling.rs
@@ -60,7 +60,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     ..default()
                 })
                 .with_children(|parent| {
-                    parent.spawn(TextBundle::from_section("Size!", text_style));
+                    parent.spawn(TextBundle::from_span("Size!", text_style));
                 });
             parent.spawn(NodeBundle {
                 style: Style {

--- a/examples/ui/ui_texture_atlas.rs
+++ b/examples/ui/ui_texture_atlas.rs
@@ -60,16 +60,16 @@ fn setup(
                 BackgroundColor(ANTIQUE_WHITE.into()),
                 Outline::new(Val::Px(8.0), Val::ZERO, CRIMSON.into()),
             ));
-            parent.spawn(TextBundle::from_sections([
-                TextSection::new("press ".to_string(), text_style.clone()),
-                TextSection::new(
+            parent.spawn(TextBundle::from_spans([
+                TextSpan::new("press ".to_string(), text_style.clone()),
+                TextSpan::new(
                     "space".to_string(),
                     TextStyle {
                         color: YELLOW.into(),
                         ..text_style.clone()
                     },
                 ),
-                TextSection::new(" to advance frames".to_string(), text_style),
+                TextSpan::new(" to advance frames".to_string(), text_style),
             ]));
         });
 }

--- a/examples/ui/ui_texture_atlas_slice.rs
+++ b/examples/ui/ui_texture_atlas_slice.rs
@@ -28,16 +28,16 @@ fn button_system(
         let mut text = text_query.get_mut(children[0]).unwrap();
         match *interaction {
             Interaction::Pressed => {
-                text.sections[0].value = "Press".to_string();
+                text.spans[0].value = "Press".to_string();
                 atlas.index = (atlas.index + 1) % 30;
                 image.color = GOLD.into();
             }
             Interaction::Hovered => {
-                text.sections[0].value = "Hover".to_string();
+                text.spans[0].value = "Hover".to_string();
                 image.color = ORANGE.into();
             }
             Interaction::None => {
-                text.sections[0].value = "Button".to_string();
+                text.spans[0].value = "Button".to_string();
                 image.color = Color::WHITE;
             }
         }
@@ -101,7 +101,7 @@ fn setup(
                         },
                     ))
                     .with_children(|parent| {
-                        parent.spawn(TextBundle::from_section(
+                        parent.spawn(TextBundle::from_span(
                             "Button",
                             TextStyle {
                                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),

--- a/examples/ui/ui_texture_slice.rs
+++ b/examples/ui/ui_texture_slice.rs
@@ -28,15 +28,15 @@ fn button_system(
         let mut text = text_query.get_mut(children[0]).unwrap();
         match *interaction {
             Interaction::Pressed => {
-                text.sections[0].value = "Press".to_string();
+                text.spans[0].value = "Press".to_string();
                 image.color = GOLD.into();
             }
             Interaction::Hovered => {
-                text.sections[0].value = "Hover".to_string();
+                text.spans[0].value = "Hover".to_string();
                 image.color = ORANGE.into();
             }
             Interaction::None => {
-                text.sections[0].value = "Button".to_string();
+                text.spans[0].value = "Button".to_string();
                 image.color = Color::WHITE;
             }
         }
@@ -86,7 +86,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         ImageScaleMode::Sliced(slicer.clone()),
                     ))
                     .with_children(|parent| {
-                        parent.spawn(TextBundle::from_section(
+                        parent.spawn(TextBundle::from_span(
                             "Button",
                             TextStyle {
                                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),

--- a/examples/ui/window_fallthrough.rs
+++ b/examples/ui/window_fallthrough.rs
@@ -25,10 +25,10 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // UI camera
     commands.spawn(Camera2dBundle::default());
-    // Text with one section
+    // Text with one span
     commands.spawn((
-        // Create a TextBundle that has a Text with a single section.
-        TextBundle::from_section(
+        // Create a TextBundle that has a Text with a single span.
+        TextBundle::from_span(
             // Accepts a `String` or any type that converts into a `String`, such as `&str`
             "Hit 'P' then scroll/click around!",
             TextStyle {

--- a/examples/window/low_power.rs
+++ b/examples/window/low_power.rs
@@ -150,8 +150,8 @@ pub(crate) mod test_setup {
             ExampleMode::ApplicationWithRedraw => "desktop_app(), reactive, RequestRedraw sent",
         };
         let mut text = query.single_mut();
-        text.sections[1].value = mode.to_string();
-        text.sections[3].value = frame.to_string();
+        text.spans[1].value = mode.to_string();
+        text.spans[3].value = frame.to_string();
     }
 
     /// Set up a scene with a cube and some text
@@ -180,20 +180,20 @@ pub(crate) mod test_setup {
         });
         event.send(RequestRedraw);
         commands.spawn((
-            TextBundle::from_sections([
-                TextSection::new(
+            TextBundle::from_spans([
+                TextSpan::new(
                     "Press space bar to cycle modes\n",
                     TextStyle {
                         font_size: 50.0,
                         ..default()
                     },
                 ),
-                TextSection::from_style(TextStyle {
+                TextSpan::from_style(TextStyle {
                     font_size: 50.0,
                     color: LIME.into(),
                     ..default()
                 }),
-                TextSection::new(
+                TextSpan::new(
                     "\nFrame: ",
                     TextStyle {
                         font_size: 50.0,
@@ -201,7 +201,7 @@ pub(crate) mod test_setup {
                         ..default()
                     },
                 ),
-                TextSection::from_style(TextStyle {
+                TextSpan::from_style(TextStyle {
                     font_size: 50.0,
                     color: YELLOW.into(),
                     ..default()

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -52,17 +52,11 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn((NodeBundle::default(), TargetCamera(first_window_camera)))
         .with_children(|parent| {
-            parent.spawn(TextBundle::from_section(
-                "First window",
-                TextStyle::default(),
-            ));
+            parent.spawn(TextBundle::from_span("First window", TextStyle::default()));
         });
     commands
         .spawn((NodeBundle::default(), TargetCamera(second_window_camera)))
         .with_children(|parent| {
-            parent.spawn(TextBundle::from_section(
-                "Second window",
-                TextStyle::default(),
-            ));
+            parent.spawn(TextBundle::from_span("Second window", TextStyle::default()));
         });
 }

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -53,7 +53,7 @@ fn setup(mut commands: Commands) {
                 .with_children(|parent| {
                     parent.spawn((
                         CustomText,
-                        TextBundle::from_section(
+                        TextBundle::from_span(
                             "Example text",
                             TextStyle {
                                 font_size: 30.0,
@@ -89,7 +89,7 @@ fn display_override(
     window.title.clone_from(&text);
 
     let mut custom_text = custom_text.single_mut();
-    custom_text.sections[0].value = text;
+    custom_text.spans[0].value = text;
 }
 
 /// This system toggles scale factor overrides when enter is pressed

--- a/examples/window/screenshot.rs
+++ b/examples/window/screenshot.rs
@@ -62,7 +62,7 @@ fn setup(
     });
 
     commands.spawn(
-        TextBundle::from_section(
+        TextBundle::from_span(
             "Press <spacebar> to save a screenshot to disk",
             TextStyle::default(),
         )

--- a/examples/window/window_resizing.rs
+++ b/examples/window/window_resizing.rs
@@ -44,7 +44,7 @@ fn setup_ui(mut cmd: Commands) {
     .with_children(|root| {
         // Text where we display current resolution
         root.spawn((
-            TextBundle::from_section(
+            TextBundle::from_span(
                 "Resolution",
                 TextStyle {
                     font_size: 50.0,
@@ -87,6 +87,6 @@ fn on_resize_system(
     let mut text = q.single_mut();
     for e in resize_reader.read() {
         // When resolution is being changed
-        text.sections[0].value = format!("{:.1} x {:.1}", e.width, e.height);
+        text.spans[0].value = format!("{:.1} x {:.1}", e.width, e.height);
     }
 }


### PR DESCRIPTION
Renames `section` to `span` when referring to text

---

## Changelog

Changes relevant function and struct names to be more in-line with nomenclature around text.

## Migration Guide

Replace all `*section` calls and references (specifically for text) with `*span`.

E.g. `TextBundle::from_sections(...` becomes `TextBundle::from_spans(...`

`TextSection` is now `TextSpan`

This PR may fit better on the main bevy repo I'm not sure if we want to roll these changes in with the cosmic switch or not, as it's a breaking change for everything that uses text.

CC @tigregalis
