### PR TITLE
Fix `ui_scaling` example failing to compile

### DIFF
--- a/examples/ui/ui_scaling.rs
+++ b/examples/ui/ui_scaling.rs
@@ -1,16 +1,12 @@
 //! This example illustrates the [`UiScale`] resource from `bevy_ui`.
 
-use bevy::{color::palettes::css::*, prelude::*, text::TextSettings, utils::Duration};
+use bevy::{color::palettes::css::*, prelude::*, utils::Duration};
 
 const SCALE_TIME: u64 = 400;
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .insert_resource(TextSettings {
-            allow_dynamic_font_size: true,
-            ..default()
-        })
         .insert_resource(TargetScale {
             start_scale: 1.0,
             target_scale: 1.0,


### PR DESCRIPTION
Fixes this example failing to compile due to `TextSettings` having been removed.

I am a bit unclear as to why it was removed -- are we not building font atlases in essentially the same way with this cosmic text integration? I didn't see an obvious replacement.

Anyhow, this makes the example compile.