### PR TITLE
round line_y

### DIFF
--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -202,7 +202,7 @@ impl TextPipeline {
 
                 // offset by half the size because the origin is center
                 let x = glyph_size.x as f32 / 2.0 + left + physical_glyph.x as f32;
-                let y = line_y + physical_glyph.y as f32 - top + glyph_size.y as f32 / 2.0;
+                let y = line_y.round() + physical_glyph.y as f32 - top + glyph_size.y as f32 / 2.0;
                 // TODO: use cosmic text's implementation (per-BufferLine alignment) as it will be editor aware
                 // see https://github.com/pop-os/cosmic-text/issues/130 (currently bugged)
                 let x = x + match text_alignment {


### PR DESCRIPTION
Glyphon and iced round it so maybe we have to do the same:

https://github.com/grovesNL/glyphon/blob/2a457087674b0c124d37c85bc6769ba27dcde173/src/text_render.rs#L179
https://github.com/iced-rs/iced/blob/714d4503154a6224c26f2eed6e399c73d57b4bf8/tiny_skia/src/text.rs#L243

![image](https://github.com/TotalKrill/bevy/assets/111751109/08b6e99a-dfc9-4233-8493-3ce38031a7f6)
![image](https://github.com/TotalKrill/bevy/assets/111751109/460210df-ae8c-45b5-89ff-a07e2da1f361)

(top images with round call)

Text looks slightly better but not sure lol
