### PR TITLE
Use cosmic-text's text alignment

### DIFF
--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -191,6 +191,21 @@ pub enum JustifyText {
     /// Rightmost character is immediately to the left of the render position.
     /// Bounds start from the render position and advance leftwards.
     Right,
+    /// Words are spaced so that leftmost & rightmost characters
+    /// align with their margins.
+    /// Bounds start from the render position and advance equally left & right.
+    Justified,
+}
+
+impl From<JustifyText> for cosmic_text::Align {
+    fn from(justify: JustifyText) -> Self {
+        match justify {
+            JustifyText::Left => cosmic_text::Align::Left,
+            JustifyText::Center => cosmic_text::Align::Center,
+            JustifyText::Right => cosmic_text::Align::Right,
+            JustifyText::Justified => cosmic_text::Align::Justified,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Reflect)]

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -16,8 +16,8 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{camera::Camera, texture::Image};
 use bevy_sprite::TextureAtlasLayout;
 use bevy_text::{
-    scale_value, BreakLineOn, CosmicBuffer, Font, FontAtlasSets, Text, TextError, TextLayoutInfo,
-    TextMeasureInfo, TextPipeline, YAxisOrientation,
+    scale_value, BreakLineOn, CosmicBuffer, Font, FontAtlasSets, JustifyText, Text, TextError,
+    TextLayoutInfo, TextMeasureInfo, TextPipeline, YAxisOrientation,
 };
 use bevy_utils::Entry;
 use taffy::style::AvailableSpace;
@@ -83,6 +83,7 @@ impl Measure for TextMeasure {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 #[inline]
 fn create_text_measure(
     fonts: &Assets<Font>,
@@ -92,6 +93,7 @@ fn create_text_measure(
     mut content_size: Mut<ContentSize>,
     mut text_flags: Mut<TextFlags>,
     buffer: &mut CosmicBuffer,
+    text_alignment: JustifyText,
 ) {
     match text_pipeline.create_text_measure(
         fonts,
@@ -99,6 +101,7 @@ fn create_text_measure(
         scale_factor,
         text.linebreak_behavior,
         buffer,
+        text_alignment,
     ) {
         Ok(measure) => {
             if text.linebreak_behavior == BreakLineOn::NoWrap {
@@ -171,6 +174,7 @@ pub fn measure_text_system(
             || text_flags.needs_new_measure_func
             || content_size.is_added()
         {
+            let text_alignment = text.justify;
             create_text_measure(
                 &fonts,
                 scale_factor.into(),
@@ -179,6 +183,7 @@ pub fn measure_text_system(
                 content_size,
                 text_flags,
                 buffer.as_mut(),
+                text_alignment,
             );
         }
     }

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -135,6 +135,22 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
             }),
         );
 
+        builder.spawn(
+            TextBundle::from_section(
+                "This text is fully justified and is positioned in the same way.",
+                TextStyle {
+                    font: font.clone(),
+                    font_size: 35.0,
+                    color: GREEN_YELLOW.into(),
+                },
+            )
+            .with_text_justify(JustifyText::Justified)
+            .with_style(Style {
+                max_width: Val::Px(300.),
+                ..default()
+            }),
+        );
+
         builder.spawn((
             TextBundle::from_sections([
                 TextSection::new(


### PR DESCRIPTION
Implement text alignment properly using cosmic-text's text alignment, instead of nudging glyphs using line width.

Removes a couple TODOs and prepares us to be able to use cosmic-text's Cursor abstraction.

For future work, if https://github.com/pop-os/cosmic-text/issues/166 is addressed we could have a small perf win as well.