### PR TITLE
Add "word or glyph" linebreaking

### DIFF
--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -121,6 +121,7 @@ impl TextPipeline {
             match linebreak_behavior {
                 BreakLineOn::WordBoundary => Wrap::Word,
                 BreakLineOn::AnyCharacter => Wrap::Glyph,
+                BreakLineOn::WordOrCharacter => Wrap::WordOrGlyph,
                 BreakLineOn::NoWrap => Wrap::None,
             },
         );

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -254,6 +254,8 @@ pub enum BreakLineOn {
     /// This is closer to the behavior one might expect from text in a terminal.
     /// However it may lead to words being broken up across linebreaks.
     AnyCharacter,
+    /// Wraps at the word level, or fallback to character level if a word can’t fit on a line by itself
+    WordOrCharacter,
     /// No soft wrapping, where text is automatically broken up into separate lines when it overflows a boundary, will ever occur.
     /// Hard wrapping, where text contains an explicit linebreak such as the escape sequence `\n`, is still enabled.
     NoWrap,

--- a/examples/ui/text_wrap_debug.rs
+++ b/examples/ui/text_wrap_debug.rs
@@ -70,6 +70,7 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
     for linebreak_behavior in [
         BreakLineOn::AnyCharacter,
         BreakLineOn::WordBoundary,
+        BreakLineOn::WordOrCharacter,
         BreakLineOn::NoWrap,
     ] {
         let row_id = commands
@@ -115,8 +116,9 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
             let messages = [
                 format!("JustifyContent::{justification:?}"),
                 format!("LineBreakOn::{linebreak_behavior:?}"),
-                "Line 1\nLine 2\nLine 3".to_string(),
+                "Line 1\nLine 2".to_string(),
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas auctor, nunc ac faucibus fringilla.".to_string(),
+                "pneumonoultramicroscopicsilicovolcanoconiosis".to_string()
             ];
 
             for (j, message) in messages.into_iter().enumerate() {


### PR DESCRIPTION
# Objective

Add support for [`cosmic_text::Wrap::WordOrGlyph`](https://docs.rs/cosmic-text/latest/cosmic_text/enum.Wrap.html)

## Solution

- Add variant to `BreakLineOn`, matching Bevy's code style
- Add a very long word to `text_wrap_debug` to demonstrate
