### PR TITLE
Text bounds

### DIFF
--- a/crates/bevy_text/src/bounds.rs
+++ b/crates/bevy_text/src/bounds.rs
@@ -34,7 +34,7 @@ impl TextBounds {
         height: None,
     };
 
-    /// Creates a new `Text2dBounds`, bounded with the specified width and height values.
+    /// Creates a new `TextBounds`, bounded with the specified width and height values.
     #[inline]
     pub const fn new(width: f32, height: f32) -> Self {
         Self {
@@ -43,7 +43,7 @@ impl TextBounds {
         }
     }
 
-    /// Creates a new `Text2dBounds`, bounded with the specified width value and unbounded on height.
+    /// Creates a new `TextBounds`, bounded with the specified width value and unbounded on height.
     #[inline]
     pub const fn new_horizontal(width: f32) -> Self {
         Self {
@@ -52,7 +52,7 @@ impl TextBounds {
         }
     }
 
-    /// Creates a new `Text2dBounds`, bounded with the specified height value and unbounded on width.
+    /// Creates a new `TextBounds`, bounded with the specified height value and unbounded on width.
     #[inline]
     pub const fn new_vertical(height: f32) -> Self {
         Self {

--- a/crates/bevy_text/src/bounds.rs
+++ b/crates/bevy_text/src/bounds.rs
@@ -1,0 +1,70 @@
+use bevy_ecs::{component::Component, reflect::ReflectComponent};
+use bevy_math::Vec2;
+use bevy_reflect::Reflect;
+
+/// The maximum width and height of text. The text will wrap according to the specified size.
+/// Characters out of the bounds after wrapping will be truncated. Text is aligned according to the
+/// specified [`JustifyText`](crate::text::JustifyText).
+///
+/// Note: only characters that are completely out of the bounds will be truncated, so this is not a
+/// reliable limit if it is necessary to contain the text strictly in the bounds. Currently this
+/// component is mainly useful for text wrapping only.
+#[derive(Component, Copy, Clone, Debug, Reflect)]
+#[reflect(Component)]
+pub struct TextBounds {
+    /// The maximum width of text in logical pixels.
+    /// If `None`, the width is unbounded.
+    pub width: Option<f32>,
+    /// The maximum height of text in logical pixels.
+    /// If `None`, the height is unbounded.
+    pub height: Option<f32>,
+}
+
+impl Default for TextBounds {
+    #[inline]
+    fn default() -> Self {
+        Self::UNBOUNDED
+    }
+}
+
+impl TextBounds {
+    /// Unbounded text will not be truncated or wrapped.
+    pub const UNBOUNDED: Self = Self {
+        width: None,
+        height: None,
+    };
+
+    /// Creates a new `Text2dBounds`, bounded with the specified width and height values.
+    #[inline]
+    pub const fn new(width: f32, height: f32) -> Self {
+        Self {
+            width: Some(width),
+            height: Some(height),
+        }
+    }
+
+    /// Creates a new `Text2dBounds`, bounded with the specified width value and unbounded on height.
+    #[inline]
+    pub const fn new_horizontal(width: f32) -> Self {
+        Self {
+            width: Some(width),
+            height: None,
+        }
+    }
+
+    /// Creates a new `Text2dBounds`, bounded with the specified height value and unbounded on width.
+    #[inline]
+    pub const fn new_vertical(height: f32) -> Self {
+        Self {
+            width: None,
+            height: Some(height),
+        }
+    }
+}
+
+impl From<Vec2> for TextBounds {
+    #[inline]
+    fn from(v: Vec2) -> Self {
+        Self::new(v.x, v.y)
+    }
+}

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -31,6 +31,7 @@
 
 #![allow(clippy::type_complexity)]
 
+mod bounds;
 mod error;
 mod font;
 mod font_atlas;
@@ -42,6 +43,8 @@ mod text;
 mod text2d;
 
 pub use cosmic_text;
+
+pub use bounds::*;
 pub use error::*;
 pub use font::*;
 pub use font_atlas::*;

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -95,7 +95,7 @@ impl Plugin for TextPlugin {
     fn build(&self, app: &mut App) {
         app.init_asset::<Font>()
             .register_type::<Text>()
-            .register_type::<Text2dBounds>()
+            .register_type::<TextBounds>()
             .init_asset_loader::<FontLoader>()
             .init_resource::<FontAtlasSets>()
             .insert_resource(TextPipeline::default())

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -12,7 +12,7 @@ use cosmic_text::{Attrs, Buffer, Family, Metrics, Shaping, Wrap};
 
 use crate::{
     error::TextError, BreakLineOn, CosmicBuffer, Font, FontAtlasSets, JustifyText, PositionedGlyph,
-    Text2dBounds, TextSection, YAxisOrientation,
+    TextBounds, TextSection, YAxisOrientation,
 };
 
 /// A wrapper around a [`cosmic_text::FontSystem`]
@@ -63,7 +63,7 @@ impl TextPipeline {
         fonts: &Assets<Font>,
         sections: &[TextSection],
         linebreak_behavior: BreakLineOn,
-        bounds: Text2dBounds,
+        bounds: TextBounds,
         scale_factor: f64,
         buffer: &mut CosmicBuffer,
         alignment: JustifyText,
@@ -149,7 +149,7 @@ impl TextPipeline {
         scale_factor: f64,
         text_alignment: JustifyText,
         linebreak_behavior: BreakLineOn,
-        bounds: Text2dBounds,
+        bounds: TextBounds,
         font_atlas_sets: &mut FontAtlasSets,
         texture_atlases: &mut Assets<TextureAtlasLayout>,
         textures: &mut Assets<Image>,
@@ -246,7 +246,7 @@ impl TextPipeline {
         buffer: &mut CosmicBuffer,
         text_alignment: JustifyText,
     ) -> Result<TextMeasureInfo, TextError> {
-        const MIN_WIDTH_CONTENT_BOUNDS: Text2dBounds = Text2dBounds::new_horizontal(0.0);
+        const MIN_WIDTH_CONTENT_BOUNDS: TextBounds = TextBounds::new_horizontal(0.0);
 
         self.update_buffer(
             fonts,
@@ -321,7 +321,7 @@ impl TextMeasureInfo {
     /// Computes the size of the text area within the provided bounds.
     pub fn compute_size(
         &mut self,
-        bounds: Text2dBounds,
+        bounds: TextBounds,
         font_system: &mut cosmic_text::FontSystem,
     ) -> Vec2 {
         self.buffer

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -12,7 +12,7 @@ use cosmic_text::{Attrs, Buffer, Family, Metrics, Shaping, Wrap};
 
 use crate::{
     error::TextError, BreakLineOn, CosmicBuffer, Font, FontAtlasSets, JustifyText, PositionedGlyph,
-    TextSection, YAxisOrientation,
+    Text2dBounds, TextSection, YAxisOrientation,
 };
 
 /// A wrapper around a [`cosmic_text::FontSystem`]
@@ -63,7 +63,7 @@ impl TextPipeline {
         fonts: &Assets<Font>,
         sections: &[TextSection],
         linebreak_behavior: BreakLineOn,
-        bounds: Vec2,
+        bounds: Text2dBounds,
         scale_factor: f64,
         buffer: &mut CosmicBuffer,
         alignment: JustifyText,
@@ -114,7 +114,7 @@ impl TextPipeline {
             .collect();
 
         buffer.set_metrics(font_system, metrics);
-        buffer.set_size(font_system, Some(bounds.x.ceil()), None);
+        buffer.set_size(font_system, bounds.width, bounds.height);
 
         buffer.set_wrap(
             font_system,
@@ -149,7 +149,7 @@ impl TextPipeline {
         scale_factor: f64,
         text_alignment: JustifyText,
         linebreak_behavior: BreakLineOn,
-        bounds: Vec2,
+        bounds: Text2dBounds,
         font_atlas_sets: &mut FontAtlasSets,
         texture_atlases: &mut Assets<TextureAtlasLayout>,
         textures: &mut Assets<Image>,
@@ -246,7 +246,7 @@ impl TextPipeline {
         buffer: &mut CosmicBuffer,
         text_alignment: JustifyText,
     ) -> Result<TextMeasureInfo, TextError> {
-        const MIN_WIDTH_CONTENT_BOUNDS: Vec2 = Vec2::new(0.0, f32::INFINITY);
+        const MIN_WIDTH_CONTENT_BOUNDS: Text2dBounds = Text2dBounds::new_horizontal(0.0);
 
         self.update_buffer(
             fonts,
@@ -321,11 +321,11 @@ impl TextMeasureInfo {
     /// Computes the size of the text area within the provided bounds.
     pub fn compute_size(
         &mut self,
-        bounds: Vec2,
+        bounds: Text2dBounds,
         font_system: &mut cosmic_text::FontSystem,
     ) -> Vec2 {
         self.buffer
-            .set_size(font_system, Some(bounds.x.ceil()), Some(bounds.y.ceil()));
+            .set_size(font_system, bounds.width, bounds.height);
         buffer_dimensions(&self.buffer)
     }
 }

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -37,7 +37,7 @@ use bevy_window::{PrimaryWindow, Window, WindowScaleFactorChanged};
 /// component is mainly useful for text wrapping only.
 #[derive(Component, Copy, Clone, Debug, Reflect)]
 #[reflect(Component)]
-pub struct Text2dBounds {
+pub struct TextBounds {
     /// The maximum width of text in logical pixels.
     /// If `None`, the width is unbounded.
     pub width: Option<f32>,
@@ -46,14 +46,14 @@ pub struct Text2dBounds {
     pub height: Option<f32>,
 }
 
-impl Default for Text2dBounds {
+impl Default for TextBounds {
     #[inline]
     fn default() -> Self {
         Self::UNBOUNDED
     }
 }
 
-impl Text2dBounds {
+impl TextBounds {
     /// Unbounded text will not be truncated or wrapped.
     pub const UNBOUNDED: Self = Self {
         width: None,
@@ -88,7 +88,7 @@ impl Text2dBounds {
     }
 }
 
-impl From<Vec2> for Text2dBounds {
+impl From<Vec2> for TextBounds {
     #[inline]
     fn from(v: Vec2) -> Self {
         Self::new(v.x, v.y)
@@ -113,7 +113,7 @@ pub struct Text2dBundle {
     /// its position.
     pub text_anchor: Anchor,
     /// The maximum width and height of the text.
-    pub text_2d_bounds: Text2dBounds,
+    pub text_2d_bounds: TextBounds,
     /// The transform of the text.
     pub transform: Transform,
     /// The global transform of the text.
@@ -224,7 +224,7 @@ pub fn update_text2d_layout(
     mut text_query: Query<(
         Entity,
         Ref<Text>,
-        Ref<Text2dBounds>,
+        Ref<TextBounds>,
         &mut TextLayoutInfo,
         &mut CosmicBuffer,
     )>,
@@ -242,7 +242,7 @@ pub fn update_text2d_layout(
 
     for (entity, text, bounds, mut text_layout_info, mut buffer) in &mut text_query {
         if factor_changed || text.is_changed() || bounds.is_changed() || queue.remove(&entity) {
-            let text_bounds = Text2dBounds {
+            let text_bounds = TextBounds {
                 width: if text.linebreak_behavior == BreakLineOn::NoWrap {
                     None
                 } else {

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -16,8 +16,8 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{camera::Camera, texture::Image};
 use bevy_sprite::TextureAtlasLayout;
 use bevy_text::{
-    scale_value, BreakLineOn, CosmicBuffer, Font, FontAtlasSets, JustifyText, Text, TextError,
-    TextLayoutInfo, TextMeasureInfo, TextPipeline, YAxisOrientation,
+    scale_value, BreakLineOn, CosmicBuffer, Font, FontAtlasSets, JustifyText, Text, Text2dBounds,
+    TextError, TextLayoutInfo, TextMeasureInfo, TextPipeline, YAxisOrientation,
 };
 use bevy_utils::Entry;
 use taffy::style::AvailableSpace;
@@ -71,9 +71,9 @@ impl Measure for TextMeasure {
         height
             .map_or_else(
                 || match available_width {
-                    AvailableSpace::Definite(_) => {
-                        self.info.compute_size(Vec2::new(x, f32::MAX), font_system)
-                    }
+                    AvailableSpace::Definite(_) => self
+                        .info
+                        .compute_size(Text2dBounds::new_horizontal(x), font_system),
                     AvailableSpace::MinContent => Vec2::new(x, self.info.min.y),
                     AvailableSpace::MaxContent => Vec2::new(x, self.info.max.y),
                 },
@@ -210,10 +210,10 @@ fn queue_text(
     if !text_flags.needs_new_measure_func {
         let physical_node_size = if text.linebreak_behavior == BreakLineOn::NoWrap {
             // With `NoWrap` set, no constraints are placed on the width of the text.
-            Vec2::splat(f32::INFINITY)
+            Text2dBounds::UNBOUNDED
         } else {
             // `scale_factor` is already multiplied by `UiScale`
-            Vec2::new(
+            Text2dBounds::new(
                 node.unrounded_size.x * scale_factor,
                 node.unrounded_size.y * scale_factor,
             )

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -16,7 +16,7 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{camera::Camera, texture::Image};
 use bevy_sprite::TextureAtlasLayout;
 use bevy_text::{
-    scale_value, BreakLineOn, CosmicBuffer, Font, FontAtlasSets, JustifyText, Text, Text2dBounds,
+    scale_value, BreakLineOn, CosmicBuffer, Font, FontAtlasSets, JustifyText, Text, TextBounds,
     TextError, TextLayoutInfo, TextMeasureInfo, TextPipeline, YAxisOrientation,
 };
 use bevy_utils::Entry;
@@ -73,7 +73,7 @@ impl Measure for TextMeasure {
                 || match available_width {
                     AvailableSpace::Definite(_) => self
                         .info
-                        .compute_size(Text2dBounds::new_horizontal(x), font_system),
+                        .compute_size(TextBounds::new_horizontal(x), font_system),
                     AvailableSpace::MinContent => Vec2::new(x, self.info.min.y),
                     AvailableSpace::MaxContent => Vec2::new(x, self.info.max.y),
                 },
@@ -210,10 +210,10 @@ fn queue_text(
     if !text_flags.needs_new_measure_func {
         let physical_node_size = if text.linebreak_behavior == BreakLineOn::NoWrap {
             // With `NoWrap` set, no constraints are placed on the width of the text.
-            Text2dBounds::UNBOUNDED
+            TextBounds::UNBOUNDED
         } else {
             // `scale_factor` is already multiplied by `UiScale`
-            Text2dBounds::new(
+            TextBounds::new(
                 node.unrounded_size.x * scale_factor,
                 node.unrounded_size.y * scale_factor,
             )

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -97,10 +97,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     justify: JustifyText::Left,
                     linebreak_behavior: BreakLineOn::WordBoundary,
                 },
-                text_2d_bounds: Text2dBounds {
-                    // Wrap text in the rectangle
-                    size: box_size,
-                },
+                // Wrap text in the rectangle
+                text_2d_bounds: Text2dBounds::from(box_size),
                 // ensure the text is drawn on top of the box
                 transform: Transform::from_translation(Vec3::Z),
                 ..default()
@@ -129,10 +127,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     justify: JustifyText::Left,
                     linebreak_behavior: BreakLineOn::AnyCharacter,
                 },
-                text_2d_bounds: Text2dBounds {
-                    // Wrap text in the rectangle
-                    size: other_box_size,
-                },
+                // Wrap text in the rectangle
+                text_2d_bounds: Text2dBounds::from(other_box_size),
                 // ensure the text is drawn on top of the box
                 transform: Transform::from_translation(Vec3::Z),
                 ..default()

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -9,7 +9,7 @@ use bevy::{
     color::palettes::css::*,
     prelude::*,
     sprite::Anchor,
-    text::{BreakLineOn, Text2dBounds},
+    text::{BreakLineOn, TextBounds},
 };
 
 fn main() {
@@ -98,7 +98,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     linebreak_behavior: BreakLineOn::WordBoundary,
                 },
                 // Wrap text in the rectangle
-                text_2d_bounds: Text2dBounds::from(box_size),
+                text_2d_bounds: TextBounds::from(box_size),
                 // ensure the text is drawn on top of the box
                 transform: Transform::from_translation(Vec3::Z),
                 ..default()
@@ -128,7 +128,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     linebreak_behavior: BreakLineOn::AnyCharacter,
                 },
                 // Wrap text in the rectangle
-                text_2d_bounds: Text2dBounds::from(other_box_size),
+                text_2d_bounds: TextBounds::from(other_box_size),
                 // ensure the text is drawn on top of the box
                 transform: Transform::from_translation(Vec3::Z),
                 ..default()

--- a/examples/stress_tests/many_glyphs.rs
+++ b/examples/stress_tests/many_glyphs.rs
@@ -83,9 +83,7 @@ fn setup(mut commands: Commands) {
     commands.spawn(Text2dBundle {
         text,
         text_anchor: bevy::sprite::Anchor::Center,
-        text_2d_bounds: Text2dBounds {
-            size: Vec2::new(1000., f32::INFINITY),
-        },
+        text_2d_bounds: Text2dBounds::new_horizontal(1000.),
         ..Default::default()
     });
 }

--- a/examples/stress_tests/many_glyphs.rs
+++ b/examples/stress_tests/many_glyphs.rs
@@ -9,7 +9,7 @@ use bevy::{
     color::palettes::basic::RED,
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
-    text::{BreakLineOn, Text2dBounds},
+    text::{BreakLineOn, TextBounds},
     window::{PresentMode, WindowResolution},
     winit::{UpdateMode, WinitSettings},
 };
@@ -83,7 +83,7 @@ fn setup(mut commands: Commands) {
     commands.spawn(Text2dBundle {
         text,
         text_anchor: bevy::sprite::Anchor::Center,
-        text_2d_bounds: Text2dBounds::new_horizontal(1000.),
+        text_2d_bounds: TextBounds::new_horizontal(1000.),
         ..Default::default()
     });
 }

--- a/examples/stress_tests/text_pipeline.rs
+++ b/examples/stress_tests/text_pipeline.rs
@@ -6,7 +6,7 @@ use bevy::{
     color::palettes::basic::{BLUE, YELLOW},
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
-    text::{BreakLineOn, Text2dBounds},
+    text::{BreakLineOn, TextBounds},
     window::{PresentMode, WindowResolution},
     winit::{UpdateMode, WinitSettings},
 };
@@ -72,7 +72,7 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
 }
 
 // changing the bounds of the text will cause a recomputation
-fn update_text_bounds(time: Res<Time>, mut text_bounds_query: Query<&mut Text2dBounds>) {
+fn update_text_bounds(time: Res<Time>, mut text_bounds_query: Query<&mut TextBounds>) {
     let width = (1. + time.elapsed_seconds().sin()) * 600.0;
     for mut text_bounds in text_bounds_query.iter_mut() {
         text_bounds.width = Some(width);

--- a/examples/stress_tests/text_pipeline.rs
+++ b/examples/stress_tests/text_pipeline.rs
@@ -75,6 +75,6 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
 fn update_text_bounds(time: Res<Time>, mut text_bounds_query: Query<&mut Text2dBounds>) {
     let width = (1. + time.elapsed_seconds().sin()) * 600.0;
     for mut text_bounds in text_bounds_query.iter_mut() {
-        text_bounds.size.x = width;
+        text_bounds.width = Some(width);
     }
 }


### PR DESCRIPTION
Fixes `examples/text2d` crash, and provides more logical API for specifying text bounds `TextBounds` including constructors.

Removed uses of `f32::MAX` and `f32::INFINITY` to represent "unbounded", replacing these with "None" (unbounded). This uses the API that landed in https://github.com/pop-os/cosmic-text/issues/70 instead. This prevents adding to overflow leading to a panic.

Repurposed `Text2dBounds` as `TextBounds`, and used it in the pipeline instead of `Vec2`.